### PR TITLE
Fix #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ git = "https://github.com/nebgnahz/cv-rs"
 features = [ "gpu" ]
 ```
 
+### Windows
+
+Depending on your install, you might have to set the `%OPENCV_DIR%`
+environment variable such that `%OPENCV_DIR%\include` points to the OpenCV
+includes diretory.
+
 ## Usage
 
 See available examples on how this library might be used.

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
         .file("native/opencv-wrapper.cc")
         .file("native/utils.cc")
         .include("/usr/local/include")
+        .include("%OPENCV_DIR%/include")
         .include("native")
         .flag("--std=c++11");
 

--- a/build.rs
+++ b/build.rs
@@ -7,9 +7,12 @@ fn main() {
         .file("native/opencv-wrapper.cc")
         .file("native/utils.cc")
         .include("/usr/local/include")
-        .include("%OPENCV_DIR%/include")
         .include("native")
         .flag("--std=c++11");
+
+    if let Ok(dir) = std::env::var("OPENCV_DIR") {
+        opencv_config.include(format!("{}\\include", dir));
+    }
 
     if cfg!(feature = "gpu") {
         opencv_config.file("native/opencv-gpu.cc");


### PR DESCRIPTION
This adds an include for `%OPENCV_DIR%\include` (if it exists) to the GCC build, which should fix #16, so long as the variable is set correctly.