### PR TITLE
Attempt to reduce copy-paste

### DIFF
--- a/native/opencv-wrapper.cc
+++ b/native/opencv-wrapper.cc
@@ -109,30 +109,17 @@ void cv_mat_drop(CvMatrix* cmat) {
     cmat = nullptr;
 }
 
-void cv_vec_of_rect_drop(VecRect* v) {
-    if (v->array != nullptr) {
-        free(v->array);
-        v->array = nullptr;
-        v->size = 0;
-    }
-}
-
-void cv_vec_of_point_drop(VecPoint* pv) {
-    if (pv->array != nullptr) {
-        free(pv->array);
-        pv->array = nullptr;
-        pv->size = 0;
-    }
-}
-
-void cv_vec_of_points_drop(VecPoints* pvs) {
-    if (pvs->array != nullptr) {
-        for (size_t i = 0; i < pvs->size; ++i) {
-            cv_vec_of_point_drop(&pvs->array[i]);
+void cv_vec_drop(Vec* vec, unsigned int depth) {
+    if (vec->array != nullptr) {
+        if (depth > 1) {
+            Vec* nestedVec = (Vec*) vec->array;
+            for (size_t i = 0; i < vec->size; ++i) {
+                cv_vec_drop(&nestedVec[i], depth - 1);
+            }
         }
-        free(pvs->array);
-        pvs->array = nullptr;
-        pvs->size = 0;
+        free(vec->array);
+        vec->array = nullptr;
+        vec->size = 0;
     }
 }
 

--- a/native/opencv-wrapper.h
+++ b/native/opencv-wrapper.h
@@ -12,6 +12,8 @@
 #define EXTERN_C_END
 #endif
 
+#define VecType(type,name) typedef struct { type* array; size_t size; } name
+
 EXTERN_C_BEGIN
 
 // =============================================================================
@@ -52,25 +54,11 @@ typedef struct {
     float angle;
 } RotatedRect;
 
-typedef struct {
-    Rect* array;
-    size_t size;
-} VecRect;
-
-typedef struct {
-    double* array;
-    size_t size;
-} VecDouble;
-
-typedef struct {
-    Point2i* array;
-    size_t size;
-} VecPoint;
-
-typedef struct {
-    VecPoint* array;
-    size_t size;
-} VecPoints;
+VecType(void, Vec);
+VecType(Rect, VecRect);
+VecType(double, VecDouble);
+VecType(Point2i, VecPoint);
+VecType(VecPoint, VecPoints);
 
 typedef struct {
     int32_t v0;
@@ -116,9 +104,7 @@ size_t cv_mat_step1(const CvMatrix* const cmat, int i);
 // Free a Mat object
 void cv_mat_drop(CvMatrix* cmat);
 
-void cv_vec_of_rect_drop(VecRect* v);
-void cv_vec_of_point_drop(VecPoint* pv);
-void cv_vec_of_points_drop(VecPoints* pvs);
+void cv_vec_drop(Vec* vec, unsigned int depth);
 
 // =============================================================================
 //  core array

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -107,8 +107,8 @@ extern "C" {
                       -> *mut CGpuHog;
     fn cv_gpu_hog_drop(hog: *mut CGpuHog);
     fn cv_gpu_hog_set_detector(hog: *mut CGpuHog, d: *const CSvmDetector);
-    fn cv_gpu_hog_detect(hog: *mut CGpuHog, mat: *mut CGpuMat, found: *mut CVecOfRect);
-    fn cv_gpu_hog_detect_with_conf(hog: *mut CGpuHog, mat: *mut CGpuMat, found: *mut CVecOfRect, conf: *mut CVecDouble);
+    fn cv_gpu_hog_detect(hog: *mut CGpuHog, mat: *mut CGpuMat, found: *mut CVec<Rect>);
+    fn cv_gpu_hog_detect_with_conf(hog: *mut CGpuHog, mat: *mut CGpuMat, found: *mut CVec<Rect>, conf: *mut CVec<c_double>);
 
     fn cv_gpu_hog_set_gamma_correction(hog: *mut CGpuHog, gamma: bool);
     fn cv_gpu_hog_set_group_threshold(hog: *mut CGpuHog, group_threshold: c_int);
@@ -223,20 +223,20 @@ impl GpuHog {
 
     /// Detects according to the SVM detector specified.
     fn _detect(&self, mat: &GpuMat) -> Vec<(Rect, f64)> {
-        let mut found = CVecOfRect::default();
+        let mut found = CVec<Rect>::default();
         unsafe {
             cv_gpu_hog_detect(self.inner, mat.inner, &mut found);
         }
-        found.rustify().into_iter().map(|r| (r, 0f64)).collect::<Vec<_>>()
+        found.unpack().into_iter().map(|r| (r, 0f64)).collect::<Vec<_>>()
     }
 
     /// Detects and returns the results with confidence (scores)
     fn _detect_with_confidence(&self, mat: &GpuMat) -> Vec<(Rect, f64)> {
-        let mut found = CVecOfRect::default();
-        let mut conf = CVecDouble::default();
+        let mut found = CVec<Rect>::default();
+        let mut conf = CVec<c_double>::default();
         unsafe { cv_gpu_hog_detect_with_conf(self.inner, mat.inner, &mut found, &mut conf) }
 
-        found.rustify().into_iter().zip(conf.rustify().into_iter()).collect::<Vec<_>>()
+        found.unpack().into_iter().zip(conf.unpack().into_iter()).collect::<Vec<_>>()
     }
 }
 

--- a/src/features2d.rs
+++ b/src/features2d.rs
@@ -15,7 +15,7 @@ extern "C" {
                    edge_blur_size: i32
     ) -> *mut CMSER;
     fn cv_mser_drop(cmser: *mut CMSER);
-    fn cv_mser_detect_regions(cmser: *const CMSER, image: *const CMat, msers: *mut CVecOfPoints, bboxes: *mut CVecOfRect);
+    fn cv_mser_detect_regions(cmser: *const CMSER, image: *const CMat, msers: *mut CVec<CVec<Point2i>>, bboxes: *mut CVec<Rect>);
 }
 
 /// Maximally stable extremal region extractor.
@@ -50,13 +50,13 @@ impl MSER {
 
     /// Detect MSER regions.
     pub fn detect_regions(&self, image: &Mat) -> (Vec<Vec<Point2i>>, Vec<Rect>) {
-        let mut msers = CVecOfPoints::default();
-        let mut bboxes = CVecOfRect::default();
+        let mut msers = CVec::<CVec<Point2i>>::default();
+        let mut bboxes = CVec::<Rect>::default();
         unsafe {
             cv_mser_detect_regions(self.value, image.inner, &mut msers, &mut bboxes);
         }
-        let msers = msers.rustify();
-        let boxes =  bboxes.rustify();
+        let msers = msers.unpack();
+        let boxes =  bboxes.unpack();
         (msers, boxes)
     }
 }

--- a/src/objdetect.rs
+++ b/src/objdetect.rs
@@ -34,7 +34,7 @@ extern "C" {
     fn cv_cascade_classifier_detect(
         cc: *mut CCascadeClassifier,
         cmat: *mut CMat,
-        vec_of_rect: *mut CVecOfRect,
+        vec_of_rect: *mut CVec<Rect>,
         scale_factor: c_double,
         min_neighbors: c_int,
         flags: c_int,
@@ -106,7 +106,7 @@ impl CascadeClassifier {
         min_size: Size2i,
         max_size: Size2i,
     ) -> Vec<Rect> {
-        let mut c_result = CVecOfRect::default();
+        let mut c_result = CVec::<Rect>::default();
         unsafe {
             cv_cascade_classifier_detect(
                 self.inner,
@@ -119,7 +119,7 @@ impl CascadeClassifier {
                 max_size,
             )
         }
-        c_result.rustify()
+        c_result.unpack()
     }
 }
 
@@ -301,8 +301,8 @@ extern "C" {
     fn cv_hog_detect(
         hog: *mut CHogDescriptor,
         image: *mut CMat,
-        objs: *mut CVecOfRect,
-        weights: *mut CVecDouble,
+        objs: *mut CVec<Rect>,
+        weights: *mut CVec<c_double>,
         win_stride: Size2i,
         padding: Size2i,
         scale: c_double,
@@ -322,8 +322,8 @@ impl Default for HogDescriptor {
 
 impl ObjectDetect for HogDescriptor {
     fn detect(&self, image: &Mat) -> Vec<(Rect, f64)> {
-        let mut detected = CVecOfRect::default();
-        let mut weights = CVecDouble::default();
+        let mut detected = CVec::<Rect>::default();
+        let mut weights = CVec::<c_double>::default();
         unsafe {
             cv_hog_detect(
                 self.inner,
@@ -338,8 +338,8 @@ impl ObjectDetect for HogDescriptor {
             )
         }
 
-        let results = detected.rustify();
-        let weights = weights.rustify();
+        let results = detected.unpack();
+        let weights = weights.unpack();
         results.into_iter().zip(weights).collect::<Vec<_>>()
     }
 }


### PR DESCRIPTION
When I was implementing MSER I noticed that I'm copy-pasting rust implementation a lot. These `CVecOfPoint` and `CVecOfPoints` was really annoying. So this MR is an attempt to reduce copy-paste. As a bonus it fixes memory leak with `CVecOfDoubles` because it wasn't implementing `Drop` trait :) 

I have added `Vec<T>` and `Vec2<T>` (which is basically `Vec<Vec<T>>`) and some implementation for them. Unfortunately, we can't write one single `Vec<T>` until `Specialization` feature is stabilized: [see my attempt](https://play.rust-lang.org/?gist=a9c9f9be56af9126d4eca0d3bd717741&version=nightly).

But `Vec` and `Vec2` seems to be good enough. At least, it will help us in not writing `CVecOfInts`, `CVecOfFloats` and others. And we won't forget implement `Drop` trait anymore ;)