### PR TITLE
Get rid of libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ description = "This library primarily provides a binding and API for OpenCV 3.x.
 bytes = "0.4.5"
 error-chain = "0.11.0"
 getopts = "0.2"
-libc = "0.2.0"
 num = "0.1"
 num-derive = "0.1"
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,7 +2,7 @@
 
 use bytes::{self, ByteOrder};
 use errors::*;
-use libc::{c_char, c_double, c_int, c_uchar, c_void, size_t};
+use std::os::raw::{c_char, c_double, c_int, c_uchar, c_void};
 use num;
 use std::ffi::CString;
 use std::mem;
@@ -316,10 +316,10 @@ extern "C" {
     fn cv_mat_depth(cmat: *const CMat) -> c_int;
     fn cv_mat_channels(cmat: *const CMat) -> c_int;
     fn cv_mat_data(cmat: *const CMat) -> *const c_uchar;
-    fn cv_mat_total(cmat: *const CMat) -> size_t;
-    fn cv_mat_step1(cmat: *const CMat, i: c_int) -> size_t;
-    fn cv_mat_elem_size(cmat: *const CMat) -> size_t;
-    fn cv_mat_elem_size1(cmat: *const CMat) -> size_t;
+    fn cv_mat_total(cmat: *const CMat) -> usize;
+    fn cv_mat_step1(cmat: *const CMat, i: c_int) -> usize;
+    fn cv_mat_elem_size(cmat: *const CMat) -> usize;
+    fn cv_mat_elem_size1(cmat: *const CMat) -> usize;
     fn cv_mat_type(cmat: *const CMat) -> c_int;
     fn cv_mat_roi(cmat: *const CMat, rect: Rect) -> *mut CMat;
     fn cv_mat_logic_and(cimage: *mut CMat, cmask: *const CMat);

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenCV's classes and functions that exploits GPU/Cuda. See
 //! [cv::cuda](http://docs.opencv.org/3.1.0/d1/d1a/namespacecv_1_1cuda.html)
 
-use libc::{c_char, c_double, c_int, size_t};
+use std::os::raw::{c_char, c_double, c_int, usize};
 use super::core::*;
 use super::errors::*;
 use super::objdetect::{CSvmDetector, HogParams, ObjectDetect, SvmDetector};
@@ -127,7 +127,7 @@ extern "C" {
     fn cv_gpu_hog_set_group_threshold(hog: *mut CGpuHog, group_threshold: c_int);
     fn cv_gpu_hog_set_hit_threshold(hog: *mut CGpuHog, hit_threshold: c_double);
     fn cv_gpu_hog_set_l2hys_threshold(hog: *mut CGpuHog, l2hys_threshold: c_double);
-    fn cv_gpu_hog_set_num_levels(hog: *mut CGpuHog, num_levels: size_t);
+    fn cv_gpu_hog_set_num_levels(hog: *mut CGpuHog, num_levels: usize);
     fn cv_gpu_hog_set_scale_factor(hog: *mut CGpuHog, scale_factor: c_double);
     fn cv_gpu_hog_set_win_sigma(hog: *mut CGpuHog, win_sigma: c_double);
     fn cv_gpu_hog_set_win_stride(hog: *mut CGpuHog, win_stride: Size2i);
@@ -136,7 +136,7 @@ extern "C" {
     fn cv_gpu_hog_get_group_threshold(hog: *mut CGpuHog) -> c_int;
     fn cv_gpu_hog_get_hit_threshold(hog: *mut CGpuHog) -> c_double;
     fn cv_gpu_hog_get_l2hys_threshold(hog: *mut CGpuHog) -> c_double;
-    fn cv_gpu_hog_get_num_levels(hog: *mut CGpuHog) -> size_t;
+    fn cv_gpu_hog_get_num_levels(hog: *mut CGpuHog) -> usize;
     fn cv_gpu_hog_get_scale_factor(hog: *mut CGpuHog) -> c_double;
     fn cv_gpu_hog_get_win_sigma(hog: *mut CGpuHog) -> c_double;
     fn cv_gpu_hog_get_win_stride(hog: *mut CGpuHog) -> Size2i;

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenCV's classes and functions that exploits GPU/Cuda. See
 //! [cv::cuda](http://docs.opencv.org/3.1.0/d1/d1a/namespacecv_1_1cuda.html)
 
-use std::os::raw::{c_char, c_double, c_int, usize};
+use std::os::raw::{c_char, c_double, c_int};
 use super::core::*;
 use super::errors::*;
 use super::objdetect::{CSvmDetector, HogParams, ObjectDetect, SvmDetector};

--- a/src/highgui.rs
+++ b/src/highgui.rs
@@ -1,6 +1,5 @@
 //! highgui: high-level GUI
-extern crate libc;
-use libc::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CString;
 use std::mem;
 use std::ptr;

--- a/src/imgcodecs.rs
+++ b/src/imgcodecs.rs
@@ -3,8 +3,8 @@
 
 use std::ffi::CString;
 use std::path::Path;
+use std::os::raw::{c_char, c_int};
 use super::core::{CMat, Mat};
-use super::libc::{c_char, c_int, size_t, uint8_t};
 
 // =============================================================================
 //  Imgproc
@@ -104,9 +104,8 @@ pub enum ImwritePngFlags {
 
 extern "C" {
     fn cv_imread(input: *const c_char, flags: c_int) -> *mut CMat;
-    fn cv_imdecode(buf: *const uint8_t, l: size_t, m: c_int) -> *mut CMat;
-    fn cv_imencode(ext: *const c_char, inner: *const CMat, flag_ptr: *const c_int, flag_size: size_t)
-        -> ImencodeResult;
+    fn cv_imdecode(buf: *const u8, l: usize, m: c_int) -> *mut CMat;
+    fn cv_imencode(ext: *const c_char, inner: *const CMat, flag_ptr: *const c_int, flag_size: usize) -> ImencodeResult;
 
 }
 

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -2,7 +2,7 @@
 //! imgproc](http://docs.opencv.org/3.1.0/d7/dbd/group__imgproc.html).
 
 use super::core::*;
-use libc::{c_double, c_float, c_int};
+use std::os::raw::{c_double, c_float, c_int};
 
 // =============================================================================
 //  Imgproc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 extern crate bytes;
 #[macro_use]
 extern crate error_chain;
-extern crate libc;
 extern crate num;
 #[macro_use]
 extern crate num_derive;

--- a/src/objdetect.rs
+++ b/src/objdetect.rs
@@ -3,7 +3,7 @@
 
 use super::core::*;
 use super::errors::*;
-use libc::{c_char, c_double, c_int};
+use std::os::raw::{c_char, c_double, c_int};
 use std::ffi::CString;
 use std::path::Path;
 use std::vec::Vec;

--- a/src/videoio.rs
+++ b/src/videoio.rs
@@ -2,7 +2,7 @@
 //! videoio](http://docs.opencv.org/3.1.0/dd/de7/group__videoio.html)
 
 use core::{CMat, Mat, Size2i};
-use libc::{c_char, c_double, c_int};
+use std::os::raw::{c_char, c_double, c_int};
 
 // =============================================================================
 //   VideoCapture


### PR DESCRIPTION
We have no need in `libc` because we must use `std::os::raw` and `std::ffi` instead.