### PR TITLE
Documentation fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "This library primarily provides a binding and API for OpenCV 3.x.
 bytes = "0.4"
 failure = "0.1"
 num = "0.1"
-num-derive = "0.1.41"
+num-derive = "=0.1.41"
 
 [dev-dependencies]
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ description = "This library primarily provides a binding and API for OpenCV 3.x.
 [dependencies]
 bytes = "0.4"
 failure = "0.1"
-getopts = "0.2"
 num = "0.1"
 num-derive = "0.1"
+
+[dev-dependencies]
+getopts = "0.2"
 
 [build-dependencies]
 gcc = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "This library primarily provides a binding and API for OpenCV 3.x.
 bytes = "0.4"
 failure = "0.1"
 num = "0.1"
-num-derive = "0.1"
+num-derive = "0.1.41"
 
 [dev-dependencies]
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "This library primarily provides a binding and API for OpenCV 3.x.
 bytes = "0.4"
 failure = "0.1"
 num = "0.1"
-num-derive = "=0.1.41"
+num-derive = "0.1"
 
 [dev-dependencies]
 getopts = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,3 +45,6 @@ build: false
 test_script:
   - cargo build --no-default-features
   - cargo test --no-default-features
+
+cache:
+  - '%USERPROFILE%\.cargo\registry'

--- a/contribute.md
+++ b/contribute.md
@@ -2,6 +2,9 @@
 
 Implement more OpenCV functions/modules and submit a PR request.
 
+Please, don't forget to run `cargo fmt` on your changes before submitting a PR.
+
+
 ```
 TODO(benzh): add more.
 ```

--- a/examples/hog.rs
+++ b/examples/hog.rs
@@ -60,8 +60,8 @@ fn run() -> Result<()> {
     let detector = SvmDetector::default_people_detector();
     hog.set_svm_detector(detector);
 
-    for entry in try!(fs::read_dir(Path::new(&dir))) {
-        let dir = try!(entry);
+    for entry in fs::read_dir(Path::new(&dir))? {
+        let dir = entry?;
         println!("Processing {:?}", dir.path());
         run_detect_for_image(&mut hog, dir.path(), show, measure);
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,9 @@
-max_width = 120
+condense_wildcard_suffixes = true
 error_on_line_overflow_comments = false
+max_width = 120
+reorder_imported_names = true
+reorder_imports = true
+reorder_imports_in_group = true
+reorder_extern_crates = true
+reorder_extern_crates_in_group = true
+use_try_shorthand = true

--- a/src/core.rs
+++ b/src/core.rs
@@ -409,8 +409,7 @@ impl Mat {
 
     /// Returns the total number of array elements. The method returns the
     /// number of array elements (a number of pixels if the array represents an
-    /// image). For example, images with 1920x1080 resolution will return
-    /// 2073600.
+    /// image). For example, images with 1920x1080 resolution will return 2073600.
     pub fn total(&self) -> usize {
         unsafe { cv_mat_total(self.inner) }
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,11 +2,11 @@
 
 use bytes::{self, ByteOrder};
 use errors::*;
-use failure::Error as Error;
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_void};
+use failure::Error;
 use num;
 use std::ffi::CString;
 use std::mem;
+use std::os::raw::{c_char, c_double, c_int, c_uchar, c_void};
 use std::slice;
 
 /// Opaque data struct for C bindings

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -1,12 +1,12 @@
 //! Bindings to OpenCV's classes and functions that exploits GPU/Cuda. See
 //! [cv::cuda](http://docs.opencv.org/3.1.0/d1/d1a/namespacecv_1_1cuda.html)
 
-use failure::Error as Error;
-use std::os::raw::{c_char, c_double, c_int};
 use super::core::*;
 use super::errors::*;
 use super::objdetect::{CSvmDetector, HogParams, ObjectDetect, SvmDetector};
+use failure::Error;
 use std::ffi::CString;
+use std::os::raw::{c_char, c_double, c_int};
 use std::path::Path;
 
 /// Opaque data struct for C/C++ cv::cuda::GpuMat bindings
@@ -313,7 +313,11 @@ impl GpuCascade {
             let inner = unsafe { cv_gpu_cascade_new((&s).as_ptr()) };
             return Ok(GpuCascade { inner: inner });
         }
-        Err(CvError::InvalidPath {path: path.as_ref().to_path_buf()}.into())
+        Err(
+            CvError::InvalidPath {
+                path: path.as_ref().to_path_buf(),
+            }.into(),
+        )
     }
 
     /// Detects objects of different sizes in the input image.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,18 +2,18 @@
 use std::path::PathBuf;
 
 #[derive(Debug, Fail)]
-///Custom errors that may happen during calls
+/// Custom errors that may happen during calls
 pub enum CvError {
     #[fail(display = "invalid path: {:?}", path)]
-    ///Indicates that path was invalid
+    /// Indicates that path was invalid
     InvalidPath {
-        ///Path that caused an error
+        /// Path that caused an error
         path: PathBuf,
     },
     #[fail(display = "failed to convert from primitive: {}", value)]
-    ///Indicates that conversion from primitive to enum type is failed
+    /// Indicates that conversion from primitive to enum type is failed
     EnumFromPrimitiveConversionError {
-        ///Value that caused an error
+        /// Value that caused an error
         value: i32,
     },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,12 +8,12 @@ pub enum CvError {
     ///Indicates that path was invalid
     InvalidPath {
         ///Path that caused an error
-        path: PathBuf
+        path: PathBuf,
     },
     #[fail(display = "failed to convert from primitive: {}", value)]
     ///Indicates that conversion from primitive to enum type is failed
     EnumFromPrimitiveConversionError {
         ///Value that caused an error
-        value: i32
+        value: i32,
     },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,19 @@
 //! Errors for OpenCV bindings
-#![allow(missing_docs)]
-
 use std::path::PathBuf;
 
 #[derive(Debug, Fail)]
+///Custom errors that may happen during calls
 pub enum CvError {
-    #[fail(display = "invalid path: {:?}", path)] InvalidPath { path: PathBuf },
-    #[fail(display = "failed to convert from primitive: {}", value)] EnumFromPrimitiveConversionError { value: i32 },
+    #[fail(display = "invalid path: {:?}", path)]
+    ///Indicates that path was invalid
+    InvalidPath {
+        ///Path that caused an error
+        path: PathBuf
+    },
+    #[fail(display = "failed to convert from primitive: {}", value)]
+    ///Indicates that conversion from primitive to enum type is failed
+    EnumFromPrimitiveConversionError {
+        ///Value that caused an error
+        value: i32
+    },
 }

--- a/src/highgui.rs
+++ b/src/highgui.rs
@@ -1,7 +1,7 @@
 //! highgui: high-level GUI
-use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CString;
 use std::mem;
+use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 
 extern "C" {

--- a/src/imgcodecs.rs
+++ b/src/imgcodecs.rs
@@ -1,10 +1,10 @@
 //! Image file reading and writing, see [OpenCV
 //! imgcodecs](http://docs.opencv.org/3.1.0/d4/da8/group__imgcodecs.html).
 
-use std::ffi::CString;
-use std::path::Path;
-use std::os::raw::{c_char, c_int};
 use super::core::{CMat, Mat};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+use std::path::Path;
 
 // =============================================================================
 //  Imgproc

--- a/src/imgcodecs.rs
+++ b/src/imgcodecs.rs
@@ -63,8 +63,8 @@ pub enum ImwriteFlags {
     /// Separate chroma quality level, 0 - 100, default is 0 - don't use.
     ImwriteJpegChromaQuality = 6,
     /// For PNG, it can be the compression level from 0 to 9. A higher value
-    /// means a smaller size and longer compression time. Default value is
-    /// 3. Also strategy is changed to IMWRITE_PNG_STRATEGY_DEFAULT
+    /// means a smaller size and longer compression time. Default value is 3.
+    /// Also strategy is changed to IMWRITE_PNG_STRATEGY_DEFAULT
     /// (Z_DEFAULT_STRATEGY).
     ImwritePngCompression = 16,
     /// One of cv::ImwritePNGFlags, default is IMWRITE_PNG_STRATEGY_DEFAULT.

--- a/src/objdetect.rs
+++ b/src/objdetect.rs
@@ -3,9 +3,9 @@
 
 use super::core::*;
 use super::errors::*;
-use failure::Error as Error;
-use std::os::raw::{c_char, c_double, c_int};
+use failure::Error;
 use std::ffi::CString;
+use std::os::raw::{c_char, c_double, c_int};
 use std::path::Path;
 use std::vec::Vec;
 
@@ -77,9 +77,11 @@ impl CascadeClassifier {
             }
         }
 
-        Err(CvError::InvalidPath {
-            path: path.as_ref().to_path_buf(),
-        }.into())
+        Err(
+            CvError::InvalidPath {
+                path: path.as_ref().to_path_buf(),
+            }.into(),
+        )
     }
 
     /// The default detection uses scale factor 1.1, minNeighbors 3, no min size

--- a/src/videoio.rs
+++ b/src/videoio.rs
@@ -185,9 +185,9 @@ impl Drop for VideoCapture {
 enum CvVideoWriter {}
 
 /// `VideoWriter` provides easy access to write videos to files.
-/// - On Linux FFMPEG is used to write videos;
-/// - On Windows FFMPEG or VFW is used;
-/// - On MacOSX QTKit is used.
+/// -On Linux FFMPEG is used to write videos;
+/// -On Windows FFMPEG or VFW is used;
+/// -On MacOSX QTKit is used.
 #[derive(Debug)]
 pub struct VideoWriter {
     inner: *mut CvVideoWriter,
@@ -220,16 +220,16 @@ extern "C" {
 
 impl VideoWriter {
     /// `VideoWriter` constructor.
-    /// * path – Name of the output video file.
-    /// * fourcc – 4-character code of codec used to compress the frames. For
-    ///   example, VideoWriter::fourcc('P','I','M','1') is a MPEG-1 codec,
-    ///   VideoWriter::fourcc('M','J','P','G') is a motion-jpeg codec etc. List
-    ///   of codes can be obtained at Video Codecs by FOURCC page.
-    /// * fps – Framerate of the created video stream.
-    /// * frame_size – Size of the video frames.
-    /// * is_color – If it is not zero, the encoder will expect and encode color
-    ///   frames, otherwise it will work with grayscale frames (the flag is
-    ///   currently supported on Windows only).
+    /// -path – Name of the output video file.
+    /// -fourcc – 4-character code of codec used to compress the frames. For
+    ///  example, VideoWriter::fourcc('P','I','M','1') is a MPEG-1 codec,
+    ///  VideoWriter::fourcc('M','J','P','G') is a motion-jpeg codec etc. List
+    ///  of codes can be obtained at Video Codecs by FOURCC page.
+    /// -fps – Framerate of the created video stream.
+    /// -frame_size – Size of the video frames.
+    /// -is_color – If it is not zero, the encoder will expect and encode color
+    ///  frames, otherwise it will work with grayscale frames (the flag is
+    ///  currently supported on Windows only).
     pub fn new(path: &str, fourcc: i32, fps: f64, frame_size: Size2i, is_color: bool) -> VideoWriter {
         let s = ::std::ffi::CString::new(path).unwrap();
         let writer = unsafe { cv_videowriter_new((&s).as_ptr(), fourcc, fps, frame_size, is_color) };
@@ -237,16 +237,16 @@ impl VideoWriter {
     }
 
     /// `VideoWriter` constructor.
-    /// * path – Name of the output video file.
-    /// * fourcc – 4-character code of codec used to compress the frames. For
-    ///   example, VideoWriter::fourcc('P','I','M','1') is a MPEG-1 codec,
-    ///   VideoWriter::fourcc('M','J','P','G') is a motion-jpeg codec etc. List
-    ///   of codes can be obtained at Video Codecs by FOURCC page.
-    /// * fps – Framerate of the created video stream.
-    /// * frame_size – Size of the video frames.
-    /// * is_color – If it is not zero, the encoder will expect and encode color
-    ///   frames, otherwise it will work with grayscale frames (the flag is
-    ///   currently supported on Windows only).
+    /// -path – Name of the output video file.
+    /// -fourcc – 4-character code of codec used to compress the frames. For
+    ///  example, VideoWriter::fourcc('P','I','M','1') is a MPEG-1 codec,
+    ///  VideoWriter::fourcc('M','J','P','G') is a motion-jpeg codec etc. List
+    ///  of codes can be obtained at Video Codecs by FOURCC page.
+    /// -fps – Framerate of the created video stream.
+    /// -frame_size – Size of the video frames.
+    /// -is_color – If it is not zero, the encoder will expect and encode color
+    ///  frames, otherwise it will work with grayscale frames (the flag is
+    ///  currently supported on Windows only).
     pub fn open(&self, path: &str, fourcc: i32, fps: f64, frame_size: Size2i, is_color: bool) -> bool {
         let s = ::std::ffi::CString::new(path).unwrap();
         unsafe { cv_videowriter_open(self.inner, (&s).as_ptr(), fourcc, fps, frame_size, is_color) }

--- a/tests/test_features2d.rs
+++ b/tests/test_features2d.rs
@@ -1,8 +1,8 @@
 extern crate cv;
 mod utils;
 
-use utils::*;
 use cv::features2d::*;
+use utils::*;
 
 #[test]
 fn mser_lenna() {

--- a/tests/test_objdetect.rs
+++ b/tests/test_objdetect.rs
@@ -12,9 +12,9 @@ use cv::cuda::GpuCascade as CascadeClassifier;
 #[cfg(not(feature = "gpu"))]
 use cv::objdetect::CascadeClassifier;
 
-use cv::objdetect::SvmDetector;
 use cv::objdetect::HogParams;
 use cv::objdetect::ObjectDetect;
+use cv::objdetect::SvmDetector;
 mod utils;
 
 #[test]


### PR DESCRIPTION
Here here docs fix (I'm done with all warnings) + I have found a solution for our examples that doesn't require any changes: just move all related dependencies in `dev-dependencies` section:

> Dev-dependencies are not used when compiling a package for building, but are used for compiling tests, **_examples_**, and benchmarks.

I have also played with appveyor cache, it gives us 20 seconds win. Well, why not?:)