### PR TITLE
check rustfmt on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 language: rust
 rust:
   - stable
+  - nightly
 
 addons:
   apt:
@@ -38,6 +39,9 @@ script:
   - cargo build --features gpu
   - cargo doc --features gpu --no-deps
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+      cargo fmt -- --write-mode=diff;
+    fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - sudo -E ./.ci/install_cuda.sh
   - sudo -E ./.ci/travis_build_opencv.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-  - which rustfmt || cargo install rustfmt-nightly
+  - rustup component add rustfmt-preview
 
 script:
   - cargo build
@@ -39,7 +39,7 @@ script:
   - cargo test --no-default-features
   - cargo build --features gpu
   - cargo doc --features gpu --no-deps
-  - find src/*.rs -exec rustfmt {} \;
+  - find src/*.rs | xargs rustfmt --write-mode=diff
   # Available until `cargo fmt` landed in stable rust 1.24
   # - cargo fmt -- --write-mode=diff;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 language: rust
 rust:
   - stable
-  - nightly
 
 addons:
   apt:
@@ -28,9 +27,11 @@ addons:
     - xvfb
 
 before_install:
+  - export PATH="$PATH:$HOME/.cargo/bin"
   - sudo -E ./.ci/install_cuda.sh
   - sudo -E ./.ci/travis_build_opencv.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+  - which rustfmt || cargo install rustfmt-nightly
 
 script:
   - cargo build
@@ -38,10 +39,7 @@ script:
   - cargo test --no-default-features
   - cargo build --features gpu
   - cargo doc --features gpu --no-deps
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench ; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-      cargo fmt -- --write-mode=diff;
-    fi
+  - cargo fmt -- --write-mode=diff;
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ script:
   - cargo test --no-default-features
   - cargo build --features gpu
   - cargo doc --features gpu --no-deps
-  - cargo fmt -- --write-mode=diff;
+  - find src/*.rs -exec rustfmt {} \;
+  # Available until `cargo fmt` landed in stable rust 1.24
+  # - cargo fmt -- --write-mode=diff;
 
 notifications:
   email:


### PR DESCRIPTION
For now, we use `rustfmt-preview` and find/xargs to run rustfmt.
Once `cargo fmt` is available in stable, we will switch to use `cargo`.

References: #45 

@Pzixel ?
