### PR TITLE
clang-format and check format on Travis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never

--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,7 @@ PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 10
 PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    true

--- a/.clang-format
+++ b/.clang-format
@@ -11,15 +11,15 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
@@ -61,7 +61,7 @@ IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -78,12 +78,12 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    true
-SpaceAfterCStyleCast: false
+SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
+SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
   apt:
     packages:
     - build-essential
+    - clang-format
     - cmake
     - git
     - libavcodec-dev
@@ -44,6 +45,10 @@ script:
   - find src/*.rs | xargs rustfmt --write-mode=diff
   # Available until `cargo fmt` landed in stable rust 1.24
   # - cargo fmt -- --write-mode=diff;
+
+  - |
+    clang-format native/* -output-replacements-xml |
+    grep -c "<replacement " > /dev/null; test $? -eq 1
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,7 @@ script:
   - find src/*.rs | xargs rustfmt --write-mode=diff
   # Available until `cargo fmt` landed in stable rust 1.24
   # - cargo fmt -- --write-mode=diff;
-  - |
-    clang-format native/* -output-replacements-xml |
-    grep -c "<replacement " > /dev/null; test $? -eq 1
+  - diff -u <(cat native/*) <(clang-format native/*)
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
   apt:
     packages:
     - build-essential
-    - clang-format
     - cmake
     - git
     - libavcodec-dev
@@ -45,7 +44,6 @@ script:
   - find src/*.rs | xargs rustfmt --write-mode=diff
   # Available until `cargo fmt` landed in stable rust 1.24
   # - cargo fmt -- --write-mode=diff;
-
   - |
     clang-format native/* -output-replacements-xml |
     grep -c "<replacement " > /dev/null; test $? -eq 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,8 @@
 
 Implement more OpenCV functions/modules and submit a PR request.
 
-Please, don't forget to run `cargo fmt` on your changes before submitting a PR.
+Before submitting a PR, make sure you have formatted both C/C++ code and Rust
+code, otherwise Travis will complain.
 
-
-```
-TODO(benzh): add more.
-```
+- For Rust, run `cargo fmt`
+- For C/C++, run `clang-format -i native/*`

--- a/native/common.h
+++ b/native/common.h
@@ -1,5 +1,10 @@
 #ifndef CV_RS_COMMON_H
 #define CV_RS_COMMON_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
 typedef struct {
     int32_t x;
     int32_t y;

--- a/native/common.h
+++ b/native/common.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <opencv2/core.hpp>
 
 typedef struct {
     int32_t x;

--- a/native/common.h
+++ b/native/common.h
@@ -56,22 +56,17 @@ typedef struct {
 } KeyPoint;
 
 // Caller is responsible for disposing `error` field
-template<typename T>
-struct Result
-{
+template <typename T>
+struct Result {
     T value;
     const char* error;
 
-    static Result<T> FromFunction(std::function<T()> function)
-    {
+    static Result<T> FromFunction(std::function<T()> function) {
         T value;
         char* error = nullptr;
-        try
-        {
+        try {
             value = function();
-        }
-        catch( cv::Exception& e )
-        {
+        } catch (cv::Exception& e) {
             const char* err_msg = e.what();
             auto len = std::strlen(err_msg);
             error = new char[len + 1];
@@ -81,10 +76,9 @@ struct Result
     }
 };
 
-template<typename T>
-struct CVec
-{
+template <typename T>
+struct CVec {
     T* array;
     size_t size;
 };
-#endif //CV_RS_COMMON_H
+#endif // CV_RS_COMMON_H

--- a/native/common.h
+++ b/native/common.h
@@ -87,4 +87,4 @@ struct CVec {
     T* array;
     size_t size;
 };
-#endif // CV_RS_COMMON_H
+#endif  // CV_RS_COMMON_H

--- a/native/opencv-gpu.cc
+++ b/native/opencv-gpu.cc
@@ -1,7 +1,8 @@
+#include <opencv2/cudaobjdetect.hpp>
+
 #include "opencv-gpu.h"
 #include "opencv-wrapper.h"
 #include "utils.h"
-#include <opencv2/cudaobjdetect.hpp>
 
 EXTERN_C_BEGIN
 
@@ -213,7 +214,7 @@ void cv_gpu_cascade_set_scale_factor(
 Size2i cv_gpu_cascade_get_classifier_size(
     cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     cv::Size2i size = (*cascade)->getClassifierSize();
-    Size2i c_size = {.width = size.width, .height = size.height};
+    Size2i c_size = {size.width, size.height};
     return c_size;
 }
 

--- a/native/opencv-gpu.cc
+++ b/native/opencv-gpu.cc
@@ -9,7 +9,9 @@ EXTERN_C_BEGIN
 // =============================================================================
 //   Basic
 // =============================================================================
-void* cv_gpu_mat_default() { return new cv::cuda::GpuMat(); }
+void* cv_gpu_mat_default() {
+    return new cv::cuda::GpuMat();
+}
 
 void cv_gpu_mat_drop(cv::cuda::GpuMat* gpu_image) {
     delete gpu_image;
@@ -36,15 +38,18 @@ void* cv_gpu_hog_default() {
     return new cv::Ptr<cv::cuda::HOG>(hog);
 }
 
-void* cv_gpu_hog_new(Size2i win_size, Size2i block_size, Size2i block_stride,
-                     Size2i cell_size, int32_t nbins) {
+void* cv_gpu_hog_new(Size2i win_size,
+                     Size2i block_size,
+                     Size2i block_stride,
+                     Size2i cell_size,
+                     int32_t nbins) {
     cv::Size cv_win_size(win_size.width, win_size.height);
     cv::Size cv_block_size(block_size.width, block_size.height);
     cv::Size cv_block_stride(block_stride.width, block_stride.height);
     cv::Size cv_cell_size(cell_size.width, cell_size.height);
 
-    auto hog = cv::cuda::HOG::create(cv_win_size, cv_block_size,
-                                     cv_block_stride, cv_cell_size, nbins);
+    auto hog = cv::cuda::HOG::create(
+        cv_win_size, cv_block_size, cv_block_stride, cv_cell_size, nbins);
     return new cv::Ptr<cv::cuda::HOG>(hog);
 }
 
@@ -58,7 +63,8 @@ void cv_gpu_hog_set_detector(cv::Ptr<cv::cuda::HOG>* hog,
     (*hog)->setSVMDetector(*detector);
 }
 
-void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>* hog, cv::cuda::GpuMat* image,
+void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>* hog,
+                       cv::cuda::GpuMat* image,
                        CVec<Rect>* found) {
     std::vector<cv::Rect> vec_object;
     (*hog)->detectMultiScale(*image, vec_object);
@@ -66,7 +72,8 @@ void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>* hog, cv::cuda::GpuMat* image,
 }
 
 void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>* hog,
-                                 cv::cuda::GpuMat* image, CVec<Rect>* found,
+                                 cv::cuda::GpuMat* image,
+                                 CVec<Rect>* found,
                                  CVec<double>* conf) {
     std::vector<cv::Rect> vec_object;
     std::vector<double> vec_confidences;
@@ -122,32 +129,26 @@ int32_t cv_gpu_hog_get_group_threshold(cv::Ptr<cv::cuda::HOG>* hog) {
 }
 
 double cv_gpu_hog_get_hit_threshold(cv::Ptr<cv::cuda::HOG>* hog) {
-
     return (*hog)->getHitThreshold();
 }
 
 double cv_gpu_hog_get_l2hys_threshold(cv::Ptr<cv::cuda::HOG>* hog) {
-
     return (*hog)->getL2HysThreshold();
 }
 
 size_t cv_gpu_hog_get_num_levels(cv::Ptr<cv::cuda::HOG>* hog) {
-
     return (*hog)->getNumLevels();
 }
 
 double cv_gpu_hog_get_scale_factor(cv::Ptr<cv::cuda::HOG>* hog) {
-
     return (*hog)->getScaleFactor();
 }
 
 double cv_gpu_hog_get_win_sigma(cv::Ptr<cv::cuda::HOG>* hog) {
-
     return (*hog)->getWinSigma();
 }
 
 Size2i cv_gpu_hog_get_win_stride(cv::Ptr<cv::cuda::HOG>* hog) {
-
     cv::Size size = (*hog)->getWinStride();
     Size2i c_size;
     c_size.width = size.width;
@@ -169,7 +170,8 @@ void cv_gpu_cascade_drop(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
 }
 
 void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>* cascade,
-                           cv::cuda::GpuMat* image, CVec<Rect>* objects) {
+                           cv::cuda::GpuMat* image,
+                           CVec<Rect>* objects) {
     cv::cuda::GpuMat objbuf;
     std::vector<cv::Rect> vec_object;
 

--- a/native/opencv-gpu.cc
+++ b/native/opencv-gpu.cc
@@ -8,9 +8,7 @@ EXTERN_C_BEGIN
 // =============================================================================
 //   Basic
 // =============================================================================
-void* cv_gpu_mat_default() {
-    return new cv::cuda::GpuMat();
-}
+void* cv_gpu_mat_default() { return new cv::cuda::GpuMat(); }
 
 void cv_gpu_mat_drop(cv::cuda::GpuMat* gpu_image) {
     delete gpu_image;
@@ -26,7 +24,7 @@ void* cv_mat_from_gpu_mat(cv::cuda::GpuMat* gpu_image) {
 }
 
 void* cv_gpu_mat_from_mat(cv::Mat* image) {
-  return new cv::cuda::GpuMat(*image);
+    return new cv::cuda::GpuMat(*image);
 }
 
 // =============================================================================
@@ -37,14 +35,15 @@ void* cv_gpu_hog_default() {
     return new cv::Ptr<cv::cuda::HOG>(hog);
 }
 
-void* cv_gpu_hog_new(Size2i win_size, Size2i block_size,
-                       Size2i block_stride, Size2i cell_size, int32_t nbins) {
+void* cv_gpu_hog_new(Size2i win_size, Size2i block_size, Size2i block_stride,
+                     Size2i cell_size, int32_t nbins) {
     cv::Size cv_win_size(win_size.width, win_size.height);
     cv::Size cv_block_size(block_size.width, block_size.height);
     cv::Size cv_block_stride(block_stride.width, block_stride.height);
     cv::Size cv_cell_size(cell_size.width, cell_size.height);
 
-    auto hog = cv::cuda::HOG::create(cv_win_size, cv_block_size, cv_block_stride, cv_cell_size, nbins);
+    auto hog = cv::cuda::HOG::create(cv_win_size, cv_block_size,
+                                     cv_block_stride, cv_cell_size, nbins);
     return new cv::Ptr<cv::cuda::HOG>(hog);
 }
 
@@ -53,17 +52,21 @@ void cv_gpu_hog_drop(cv::Ptr<cv::cuda::HOG>* hog) {
     hog = nullptr;
 }
 
-void cv_gpu_hog_set_detector(cv::Ptr<cv::cuda::HOG>* hog, std::vector<float>* detector) {
+void cv_gpu_hog_set_detector(cv::Ptr<cv::cuda::HOG>* hog,
+                             std::vector<float>* detector) {
     (*hog)->setSVMDetector(*detector);
 }
 
-void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>* hog, cv::cuda::GpuMat* image, CVec<Rect>* found) {
+void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>* hog, cv::cuda::GpuMat* image,
+                       CVec<Rect>* found) {
     std::vector<cv::Rect> vec_object;
     (*hog)->detectMultiScale(*image, vec_object);
     cv_to_ffi(vec_object, found);
 }
 
-void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>* hog, cv::cuda::GpuMat* image, CVec<Rect>* found, CVec<double>* conf) {
+void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>* hog,
+                                 cv::cuda::GpuMat* image, CVec<Rect>* found,
+                                 CVec<double>* conf) {
     std::vector<cv::Rect> vec_object;
     std::vector<double> vec_confidences;
     (*hog)->setGroupThreshold(0);
@@ -76,15 +79,18 @@ void cv_gpu_hog_set_gamma_correction(cv::Ptr<cv::cuda::HOG>* hog, bool gamma) {
     (*hog)->setGammaCorrection(gamma);
 }
 
-void cv_gpu_hog_set_group_threshold(cv::Ptr<cv::cuda::HOG>* hog, int32_t group_threshold) {
+void cv_gpu_hog_set_group_threshold(cv::Ptr<cv::cuda::HOG>* hog,
+                                    int32_t group_threshold) {
     (*hog)->setGroupThreshold(group_threshold);
 }
 
-void cv_gpu_hog_set_hit_threshold(cv::Ptr<cv::cuda::HOG>* hog, double hit_threshold) {
+void cv_gpu_hog_set_hit_threshold(cv::Ptr<cv::cuda::HOG>* hog,
+                                  double hit_threshold) {
     (*hog)->setHitThreshold(hit_threshold);
 }
 
-void cv_gpu_hog_set_l2hys_threshold(cv::Ptr<cv::cuda::HOG>* hog, double l2hys_threshold) {
+void cv_gpu_hog_set_l2hys_threshold(cv::Ptr<cv::cuda::HOG>* hog,
+                                    double l2hys_threshold) {
     (*hog)->setL2HysThreshold(l2hys_threshold);
 }
 
@@ -92,7 +98,8 @@ void cv_gpu_hog_set_num_levels(cv::Ptr<cv::cuda::HOG>* hog, size_t num_levels) {
     (*hog)->setNumLevels(num_levels);
 }
 
-void cv_gpu_hog_set_scale_factor(cv::Ptr<cv::cuda::HOG>* hog, double scale_factor) {
+void cv_gpu_hog_set_scale_factor(cv::Ptr<cv::cuda::HOG>* hog,
+                                 double scale_factor) {
     (*hog)->setScaleFactor(scale_factor);
 }
 
@@ -147,7 +154,6 @@ Size2i cv_gpu_hog_get_win_stride(cv::Ptr<cv::cuda::HOG>* hog) {
     return c_size;
 }
 
-
 // =============================================================================
 //   CascadeClassifier
 // =============================================================================
@@ -161,7 +167,8 @@ void cv_gpu_cascade_drop(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     cascade = nullptr;
 }
 
-void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, cv::cuda::GpuMat* image, CVec<Rect>* objects) {
+void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>* cascade,
+                           cv::cuda::GpuMat* image, CVec<Rect>* objects) {
     cv::cuda::GpuMat objbuf;
     std::vector<cv::Rect> vec_object;
 
@@ -171,63 +178,76 @@ void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, cv::cu
     cv_to_ffi(vec_object, objects);
 }
 
-void cv_gpu_cascade_set_find_largest_object(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, bool value) {
+void cv_gpu_cascade_set_find_largest_object(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, bool value) {
     (*cascade)->setFindLargestObject(value);
 }
 
-void cv_gpu_cascade_set_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, int32_t num) {
+void cv_gpu_cascade_set_max_num_objects(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, int32_t num) {
     (*cascade)->setMaxNumObjects(num);
 }
 
-void cv_gpu_cascade_set_min_neighbors(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, int32_t min) {
+void cv_gpu_cascade_set_min_neighbors(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, int32_t min) {
     (*cascade)->setMinNeighbors(min);
 }
 
-void cv_gpu_cascade_set_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, Size2i max_size) {
+void cv_gpu_cascade_set_max_object_size(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, Size2i max_size) {
     cv::Size cv_max_size(max_size.width, max_size.height);
     (*cascade)->setMaxObjectSize(cv_max_size);
 }
 
-void cv_gpu_cascade_set_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, Size2i min_size) {
+void cv_gpu_cascade_set_min_object_size(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, Size2i min_size) {
     cv::Size cv_min_size(min_size.width, min_size.height);
     (*cascade)->setMinObjectSize(cv_min_size);
 }
 
-void cv_gpu_cascade_set_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>* cascade, double factor) {
+void cv_gpu_cascade_set_scale_factor(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade, double factor) {
     (*cascade)->setScaleFactor(factor);
 }
 
-Size2i cv_gpu_cascade_get_classifier_size(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+Size2i cv_gpu_cascade_get_classifier_size(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     cv::Size2i size = (*cascade)->getClassifierSize();
-    Size2i c_size = {.width = size.width, .height = size.height };
+    Size2i c_size = {.width = size.width, .height = size.height};
     return c_size;
 }
 
-bool cv_gpu_cascade_get_find_largest_object(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+bool cv_gpu_cascade_get_find_largest_object(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     return (*cascade)->getFindLargestObject();
 }
 
-int32_t cv_gpu_cascade_get_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+int32_t cv_gpu_cascade_get_max_num_objects(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     return (*cascade)->getMaxNumObjects();
 }
 
-int32_t cv_gpu_cascade_get_min_neighbors(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+int32_t cv_gpu_cascade_get_min_neighbors(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     return (*cascade)->getMinNeighbors();
 }
 
-Size2i cv_gpu_cascade_get_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+Size2i cv_gpu_cascade_get_max_object_size(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     cv::Size2i size = (*cascade)->getMaxObjectSize();
     Size2i c_size = {.width = size.width, .height = size.height};
     return c_size;
 }
 
-Size2i cv_gpu_cascade_get_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+Size2i cv_gpu_cascade_get_min_object_size(
+    cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     cv::Size2i size = (*cascade)->getMinObjectSize();
     Size2i c_size = {.width = size.width, .height = size.height};
     return c_size;
 }
 
-double cv_gpu_cascade_get_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
+double
+cv_gpu_cascade_get_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>* cascade) {
     return (*cascade)->getScaleFactor();
 }
 

--- a/native/opencv-gpu.h
+++ b/native/opencv-gpu.h
@@ -23,13 +23,18 @@ void* cv_gpu_mat_from_mat(cv::Mat*);
 //   Hog
 // =============================================================================
 void* cv_gpu_hog_default();
-void* cv_gpu_hog_new(Size2i win_size, Size2i block_size, Size2i block_stride,
-                     Size2i cell_size, int32_t nbins);
+void* cv_gpu_hog_new(Size2i win_size,
+                     Size2i block_size,
+                     Size2i block_stride,
+                     Size2i cell_size,
+                     int32_t nbins);
 void cv_gpu_hog_drop(cv::Ptr<cv::cuda::HOG>*);
 void cv_gpu_hog_set_detector(cv::Ptr<cv::cuda::HOG>*, std::vector<float>*);
 void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>*, cv::cuda::GpuMat*, CVec<Rect>*);
-void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>*, cv::cuda::GpuMat*,
-                                 CVec<Rect>*, CVec<double>*);
+void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>*,
+                                 cv::cuda::GpuMat*,
+                                 CVec<Rect>*,
+                                 CVec<double>*);
 
 void cv_gpu_hog_set_gamma_correction(cv::Ptr<cv::cuda::HOG>*, bool gamma);
 void cv_gpu_hog_set_group_threshold(cv::Ptr<cv::cuda::HOG>*,
@@ -58,7 +63,8 @@ Size2i cv_gpu_hog_get_win_stride(cv::Ptr<cv::cuda::HOG>*);
 void* cv_gpu_cascade_new(const char* const filename);
 void cv_gpu_cascade_drop(cv::Ptr<cv::cuda::CascadeClassifier>*);
 void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>*,
-                           cv::cuda::GpuMat*, CVec<Rect>*);
+                           cv::cuda::GpuMat*,
+                           CVec<Rect>*);
 
 void cv_gpu_cascade_set_find_largest_object(
     cv::Ptr<cv::cuda::CascadeClassifier>*, bool);
@@ -88,4 +94,4 @@ double cv_gpu_cascade_get_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>*);
 
 EXTERN_C_END
 
-#endif // OPENCV_GPU_H_
+#endif  // OPENCV_GPU_H_

--- a/native/opencv-gpu.h
+++ b/native/opencv-gpu.h
@@ -3,10 +3,10 @@
 #define EXTERN_C_BEGIN extern "C" {
 #define EXTERN_C_END }
 
+#include "common.h"
+#include <opencv2/cudaobjdetect.hpp>
 #include <stddef.h>
 #include <stdint.h>
-#include <opencv2/cudaobjdetect.hpp>
-#include "common.h"
 
 EXTERN_C_BEGIN
 
@@ -23,17 +23,21 @@ void* cv_gpu_mat_from_mat(cv::Mat*);
 //   Hog
 // =============================================================================
 void* cv_gpu_hog_default();
-void* cv_gpu_hog_new(Size2i win_size, Size2i block_size,
-                     Size2i block_stride, Size2i cell_size, int32_t nbins);
+void* cv_gpu_hog_new(Size2i win_size, Size2i block_size, Size2i block_stride,
+                     Size2i cell_size, int32_t nbins);
 void cv_gpu_hog_drop(cv::Ptr<cv::cuda::HOG>*);
 void cv_gpu_hog_set_detector(cv::Ptr<cv::cuda::HOG>*, std::vector<float>*);
 void cv_gpu_hog_detect(cv::Ptr<cv::cuda::HOG>*, cv::cuda::GpuMat*, CVec<Rect>*);
-void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>*, cv::cuda::GpuMat*, CVec<Rect>*, CVec<double>*);
+void cv_gpu_hog_detect_with_conf(cv::Ptr<cv::cuda::HOG>*, cv::cuda::GpuMat*,
+                                 CVec<Rect>*, CVec<double>*);
 
 void cv_gpu_hog_set_gamma_correction(cv::Ptr<cv::cuda::HOG>*, bool gamma);
-void cv_gpu_hog_set_group_threshold(cv::Ptr<cv::cuda::HOG>*, int32_t group_threshold);
-void cv_gpu_hog_set_hit_threshold(cv::Ptr<cv::cuda::HOG>*, double hit_threshold);
-void cv_gpu_hog_set_l2hys_threshold(cv::Ptr<cv::cuda::HOG>*, double l2hys_threshold);
+void cv_gpu_hog_set_group_threshold(cv::Ptr<cv::cuda::HOG>*,
+                                    int32_t group_threshold);
+void cv_gpu_hog_set_hit_threshold(cv::Ptr<cv::cuda::HOG>*,
+                                  double hit_threshold);
+void cv_gpu_hog_set_l2hys_threshold(cv::Ptr<cv::cuda::HOG>*,
+                                    double l2hys_threshold);
 void cv_gpu_hog_set_num_levels(cv::Ptr<cv::cuda::HOG>*, size_t num_levels);
 void cv_gpu_hog_set_scale_factor(cv::Ptr<cv::cuda::HOG>*, double scale_factor);
 void cv_gpu_hog_set_win_sigma(cv::Ptr<cv::cuda::HOG>*, double win_sigma);
@@ -46,30 +50,42 @@ double cv_gpu_hog_get_l2hys_threshold(cv::Ptr<cv::cuda::HOG>*);
 size_t cv_gpu_hog_get_num_levels(cv::Ptr<cv::cuda::HOG>*);
 double cv_gpu_hog_get_scale_factor(cv::Ptr<cv::cuda::HOG>*);
 double cv_gpu_hog_get_win_sigma(cv::Ptr<cv::cuda::HOG>*);
-Size2i cv_gpu_hog_get_win_stride(cv::Ptr<cv::cuda::HOG> *);
+Size2i cv_gpu_hog_get_win_stride(cv::Ptr<cv::cuda::HOG>*);
 
 // =============================================================================
 //   CascadeClassifier
 // =============================================================================
 void* cv_gpu_cascade_new(const char* const filename);
 void cv_gpu_cascade_drop(cv::Ptr<cv::cuda::CascadeClassifier>*);
-void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>*, cv::cuda::GpuMat*, CVec<Rect>*);
+void cv_gpu_cascade_detect(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                           cv::cuda::GpuMat*, CVec<Rect>*);
 
-void cv_gpu_cascade_set_find_largest_object(cv::Ptr<cv::cuda::CascadeClassifier>*, bool);
-void cv_gpu_cascade_set_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>*, int32_t);
-void cv_gpu_cascade_set_min_neighbors(cv::Ptr<cv::cuda::CascadeClassifier>*, int32_t);
-void cv_gpu_cascade_set_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*, Size2i);
-void cv_gpu_cascade_set_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*, Size2i);
-void cv_gpu_cascade_set_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>*, double);
+void cv_gpu_cascade_set_find_largest_object(
+    cv::Ptr<cv::cuda::CascadeClassifier>*, bool);
+void cv_gpu_cascade_set_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                                        int32_t);
+void cv_gpu_cascade_set_min_neighbors(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                                      int32_t);
+void cv_gpu_cascade_set_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                                        Size2i);
+void cv_gpu_cascade_set_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                                        Size2i);
+void cv_gpu_cascade_set_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>*,
+                                     double);
 
-Size2i cv_gpu_cascade_get_classifier_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
-bool cv_gpu_cascade_get_find_largest_object(cv::Ptr<cv::cuda::CascadeClassifier>*);
-int32_t cv_gpu_cascade_get_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>*);
+Size2i
+cv_gpu_cascade_get_classifier_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
+bool cv_gpu_cascade_get_find_largest_object(
+    cv::Ptr<cv::cuda::CascadeClassifier>*);
+int32_t
+cv_gpu_cascade_get_max_num_objects(cv::Ptr<cv::cuda::CascadeClassifier>*);
 int32_t cv_gpu_cascade_get_min_neighbors(cv::Ptr<cv::cuda::CascadeClassifier>*);
-Size2i cv_gpu_cascade_get_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
-Size2i cv_gpu_cascade_get_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
+Size2i
+cv_gpu_cascade_get_max_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
+Size2i
+cv_gpu_cascade_get_min_object_size(cv::Ptr<cv::cuda::CascadeClassifier>*);
 double cv_gpu_cascade_get_scale_factor(cv::Ptr<cv::cuda::CascadeClassifier>*);
 
 EXTERN_C_END
 
-#endif  // OPENCV_GPU_H_
+#endif // OPENCV_GPU_H_

--- a/native/opencv-wrapper.cc
+++ b/native/opencv-wrapper.cc
@@ -1,6 +1,3 @@
-#include "opencv-wrapper.h"
-#include "utils.h"
-
 #include <opencv2/core.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>
@@ -8,6 +5,9 @@
 #include <opencv2/objdetect.hpp>
 #include <opencv2/video/tracking.hpp>
 #include <opencv2/xfeatures2d.hpp>
+
+#include "opencv-wrapper.h"
+#include "utils.h"
 
 EXTERN_C_BEGIN
 

--- a/native/opencv-wrapper.cc
+++ b/native/opencv-wrapper.cc
@@ -30,11 +30,15 @@ void* cv_mat_zeros(int rows, int cols, int type) {
 }
 
 void* cv_mat_from_buffer(int rows, int cols, int type, const uint8_t* buf) {
-    return (new cv::Mat(rows, cols, type,
+    return (new cv::Mat(rows,
+                        cols,
+                        type,
                         const_cast<void*>(reinterpret_cast<const void*>(buf))));
 }
 
-bool cv_mat_is_valid(cv::Mat* mat) { return mat->data != NULL; }
+bool cv_mat_is_valid(cv::Mat* mat) {
+    return mat->data != NULL;
+}
 
 void* cv_mat_roi(cv::Mat* mat, Rect crect) {
     cv::Rect rect(crect.x, crect.y, crect.width, crect.height);
@@ -46,7 +50,9 @@ void cv_mat_logic_and(cv::Mat* image, const cv::Mat* const mask) {
     (*image) &= (*mask);
 }
 
-void cv_mat_flip(cv::Mat* image, int code) { cv::flip(*image, *image, code); }
+void cv_mat_flip(cv::Mat* image, int code) {
+    cv::flip(*image, *image, code);
+}
 
 void* cv_imread(const char* const filename, int flags) {
     cv::Mat* image = new cv::Mat();
@@ -54,25 +60,45 @@ void* cv_imread(const char* const filename, int flags) {
     return (image);
 }
 
-int cv_mat_cols(const cv::Mat* const mat) { return mat->cols; }
+int cv_mat_cols(const cv::Mat* const mat) {
+    return mat->cols;
+}
 
-int cv_mat_rows(const cv::Mat* const mat) { return mat->rows; }
+int cv_mat_rows(const cv::Mat* const mat) {
+    return mat->rows;
+}
 
-int cv_mat_depth(const cv::Mat* const mat) { return mat->depth(); }
+int cv_mat_depth(const cv::Mat* const mat) {
+    return mat->depth();
+}
 
-int cv_mat_channels(const cv::Mat* const mat) { return mat->channels(); }
+int cv_mat_channels(const cv::Mat* const mat) {
+    return mat->channels();
+}
 
-int cv_mat_type(const cv::Mat* const mat) { return mat->type(); }
+int cv_mat_type(const cv::Mat* const mat) {
+    return mat->type();
+}
 
-const uint8_t* cv_mat_data(const cv::Mat* const mat) { return mat->data; }
+const uint8_t* cv_mat_data(const cv::Mat* const mat) {
+    return mat->data;
+}
 
-size_t cv_mat_total(const cv::Mat* const mat) { return mat->total(); }
+size_t cv_mat_total(const cv::Mat* const mat) {
+    return mat->total();
+}
 
-size_t cv_mat_elem_size(const cv::Mat* const mat) { return mat->elemSize(); }
+size_t cv_mat_elem_size(const cv::Mat* const mat) {
+    return mat->elemSize();
+}
 
-size_t cv_mat_elem_size1(const cv::Mat* const mat) { return mat->elemSize1(); }
+size_t cv_mat_elem_size1(const cv::Mat* const mat) {
+    return mat->elemSize1();
+}
 
-size_t cv_mat_step1(const cv::Mat* const mat, int i) { return mat->step1(i); }
+size_t cv_mat_step1(const cv::Mat* const mat, int i) {
+    return mat->step1(i);
+}
 
 void cv_mat_drop(cv::Mat* mat) {
     delete mat;
@@ -82,7 +108,7 @@ void cv_mat_drop(cv::Mat* mat) {
 void cv_vec_drop(CVec<void>* vec, unsigned int depth) {
     if (vec->array != nullptr) {
         if (depth > 1) {
-            auto nestedVec = (CVec<void>*)vec->array;
+            auto nestedVec = (CVec<void>*) vec->array;
             for (size_t i = 0; i < vec->size; ++i) {
                 cv_vec_drop(&nestedVec[i], depth - 1);
             }
@@ -107,8 +133,11 @@ void cv_in_range(cv::Mat* mat, Scalar lowerb, Scalar upperb, cv::Mat* dst) {
     cv::inRange(*mat, lb, ub, *dst);
 }
 
-void cv_min_max_loc(const cv::Mat* const mat, double* min, double* max,
-                    Point2i* minLoc, Point2i* maxLoc,
+void cv_min_max_loc(const cv::Mat* const mat,
+                    double* min,
+                    double* max,
+                    Point2i* minLoc,
+                    Point2i* maxLoc,
                     const cv::Mat* const mask) {
     if (minLoc == NULL && maxLoc == NULL) {
         cv::minMaxLoc(*mat, min, max, NULL, NULL, *mask);
@@ -133,17 +162,22 @@ void cv_min_max_loc(const cv::Mat* const mat, double* min, double* max,
     }
 }
 
-void cv_mix_channels(cv::Mat* src, size_t nsrcs, cv::Mat* dst, size_t ndsts,
-                     const int* from_to, size_t npairs) {
+void cv_mix_channels(cv::Mat* src,
+                     size_t nsrcs,
+                     cv::Mat* dst,
+                     size_t ndsts,
+                     const int* from_to,
+                     size_t npairs) {
     cv::mixChannels(src, nsrcs, dst, ndsts, from_to, npairs);
 }
 
-void cv_normalize(cv::Mat* src, cv::Mat* dst, double alpha, double beta,
-                  int norm_type) {
+void cv_normalize(
+    cv::Mat* src, cv::Mat* dst, double alpha, double beta, int norm_type) {
     cv::normalize(*src, *dst, alpha, beta, norm_type);
 }
 
-void cv_bitwise_and(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_bitwise_and(const cv::Mat* const src1,
+                    const cv::Mat* const src2,
                     cv::Mat* dst) {
     cv::bitwise_and(*src1, *src2, *dst);
 }
@@ -152,12 +186,14 @@ void cv_bitwise_not(const cv::Mat* const src, cv::Mat* const dst) {
     cv::bitwise_not(*src, *dst);
 }
 
-void cv_bitwise_or(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_bitwise_or(const cv::Mat* const src1,
+                   const cv::Mat* const src2,
                    cv::Mat* dst) {
     cv::bitwise_or(*src1, *src2, *dst);
 }
 
-void cv_bitwise_xor(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_bitwise_xor(const cv::Mat* const src1,
+                    const cv::Mat* const src2,
                     cv::Mat* dst) {
     cv::bitwise_xor(*src1, *src2, *dst);
 }
@@ -169,56 +205,90 @@ int cv_count_non_zero(const cv::Mat* const src) {
 // =============================================================================
 //  Imgproc
 // =============================================================================
-void cv_line(cv::Mat* mat, Point2i pt1, Point2i pt2, Scalar color,
-             int thickness, int linetype, int shift) {
+void cv_line(cv::Mat* mat,
+             Point2i pt1,
+             Point2i pt2,
+             Scalar color,
+             int thickness,
+             int linetype,
+             int shift) {
     cv::Point point1(pt1.x, pt1.y);
     cv::Point point2(pt2.x, pt2.y);
     cv::Scalar colour(color.v0, color.v1, color.v2, color.v3);
     cv::line(*mat, point1, point2, colour, thickness, linetype, shift);
 }
 
-void cv_rectangle(cv::Mat* mat, Rect crect, Scalar color, int thickness,
-                  int linetype) {
+void cv_rectangle(
+    cv::Mat* mat, Rect crect, Scalar color, int thickness, int linetype) {
     cv::Rect rect(crect.x, crect.y, crect.width, crect.height);
     cv::Scalar colour(color.v0, color.v1, color.v2, color.v3);
     cv::rectangle(*mat, rect, colour, thickness, linetype);
 }
 
-void cv_ellipse(cv::Mat* mat, Point2i center, Size2i axes, double angle,
-                double start_angle, double end_angle, Scalar color,
-                int thickness, int linetype, int shift) {
+void cv_ellipse(cv::Mat* mat,
+                Point2i center,
+                Size2i axes,
+                double angle,
+                double start_angle,
+                double end_angle,
+                Scalar color,
+                int thickness,
+                int linetype,
+                int shift) {
     cv::Point cv_center(center.x, center.y);
     cv::Size cv_axes(axes.width, axes.height);
     cv::Scalar cv_color(color.v0, color.v1, color.v2, color.v3);
 
-    cv::ellipse(*mat, cv_center, cv_axes, angle, start_angle, end_angle,
-                cv_color, thickness, linetype, shift);
+    cv::ellipse(*mat,
+                cv_center,
+                cv_axes,
+                angle,
+                start_angle,
+                end_angle,
+                cv_color,
+                thickness,
+                linetype,
+                shift);
 }
 
 void cv_cvt_color(cv::Mat* mat, cv::Mat* out, int code) {
     cv::cvtColor(*mat, *out, code);
 }
 
-void cv_pyr_down(cv::Mat* mat, cv::Mat* out) { cv::pyrDown(*mat, *out); }
+void cv_pyr_down(cv::Mat* mat, cv::Mat* out) {
+    cv::pyrDown(*mat, *out);
+}
 
-void cv_resize(cv::Mat* from, cv::Mat* to, Size2i dsize, double fx, double fy,
+void cv_resize(cv::Mat* from,
+               cv::Mat* to,
+               Size2i dsize,
+               double fx,
+               double fy,
                int interpolation) {
     cv::Size cv_dsize(dsize.width, dsize.height);
     cv::resize(*from, *to, cv_dsize, fx, fy, interpolation);
 }
 
-void cv_calc_hist(const cv::Mat* images, int nimages, const int* channels,
-                  cv::Mat* mask, cv::Mat* hist, int dims, const int* hist_size,
+void cv_calc_hist(const cv::Mat* images,
+                  int nimages,
+                  const int* channels,
+                  cv::Mat* mask,
+                  cv::Mat* hist,
+                  int dims,
+                  const int* hist_size,
                   const float** ranges) {
-    cv::calcHist(images, nimages, channels, *mask, *hist, dims, hist_size,
-                 ranges);
+    cv::calcHist(
+        images, nimages, channels, *mask, *hist, dims, hist_size, ranges);
 }
 
-void cv_calc_back_project(const cv::Mat* images, int nimages,
-                          const int* channels, cv::Mat* hist,
-                          cv::Mat* back_project, const float** ranges) {
-    cv::calcBackProject(images, nimages, channels, *hist, *back_project,
-                        ranges);
+void cv_calc_back_project(const cv::Mat* images,
+                          int nimages,
+                          const int* channels,
+                          cv::Mat* hist,
+                          cv::Mat* back_project,
+                          const float** ranges) {
+    cv::calcBackProject(
+        images, nimages, channels, *hist, *back_project, ranges);
 }
 
 // =============================================================================
@@ -232,8 +302,10 @@ void* cv_imdecode(const uint8_t* const buffer, size_t len, int flag) {
 }
 
 // The caller is responsible for the allocated buffer
-ImencodeResult cv_imencode(const char* const ext, const cv::Mat* const image,
-                           const int* const flag_ptr, size_t flag_size) {
+ImencodeResult cv_imencode(const char* const ext,
+                           const cv::Mat* const image,
+                           const int* const flag_ptr,
+                           size_t flag_size) {
     std::vector<uchar> buf;
     std::vector<int> params(flag_ptr, flag_ptr + flag_size);
     bool r = cv::imencode(ext, *image, buf, params);
@@ -266,9 +338,12 @@ void cv_imshow(const char* const winname, cv::Mat* mat) {
     }
 }
 
-int cv_wait_key(int delay) { return cv::waitKey(delay); }
+int cv_wait_key(int delay) {
+    return cv::waitKey(delay);
+}
 
-void cv_set_mouse_callback(const char* const winname, MouseCallback on_mouse,
+void cv_set_mouse_callback(const char* const winname,
+                           MouseCallback on_mouse,
                            void* userdata) {
     cv::setMouseCallback(winname, on_mouse, userdata);
 }
@@ -276,7 +351,9 @@ void cv_set_mouse_callback(const char* const winname, MouseCallback on_mouse,
 // =============================================================================
 //   VideoCapture
 // =============================================================================
-void* cv_videocapture_new(int index) { return new cv::VideoCapture(index); }
+void* cv_videocapture_new(int index) {
+    return new cv::VideoCapture(index);
+}
 
 void* cv_videocapture_from_file(const char* const filename) {
     return new cv::VideoCapture(filename);
@@ -308,14 +385,19 @@ double cv_videocapture_get(cv::VideoCapture* cap, int property) {
 // =============================================================================
 /// http://www.fourcc.org/codecs.php
 int cv_fourcc(char c1, char c2, char c3, char c4) {
-    return (((c1)&255) + (((c2)&255) << 8) + (((c3)&255) << 16) +
-            (((c4)&255) << 24));
+    return (((c1) &255) + (((c2) &255) << 8) + (((c3) &255) << 16) +
+            (((c4) &255) << 24));
 }
 
-void* cv_videowriter_default() { return new cv::VideoWriter(); }
+void* cv_videowriter_default() {
+    return new cv::VideoWriter();
+}
 
-void* cv_videowriter_new(const char* const path, int fourcc, double fps,
-                         Size2i frame_size, bool is_color) {
+void* cv_videowriter_new(const char* const path,
+                         int fourcc,
+                         double fps,
+                         Size2i frame_size,
+                         bool is_color) {
     cv::Size cv_frame_size(frame_size.width, frame_size.height);
     cv::VideoWriter* writer =
         new cv::VideoWriter(path, fourcc, fps, cv_frame_size, is_color);
@@ -327,8 +409,11 @@ void cv_videowriter_drop(cv::VideoWriter* writer) {
     writer = nullptr;
 }
 
-bool cv_videowriter_open(cv::VideoWriter* writer, const char* const path,
-                         int fourcc, double fps, Size2i frame_size,
+bool cv_videowriter_open(cv::VideoWriter* writer,
+                         const char* const path,
+                         int fourcc,
+                         double fps,
+                         Size2i frame_size,
                          bool is_color) {
     cv::Size cv_frame_size(frame_size.width, frame_size.height);
     return writer->open(path, fourcc, fps, cv_frame_size, is_color);
@@ -353,7 +438,9 @@ double cv_videowriter_get(cv::VideoWriter* writer, int property) {
 // =============================================================================
 //   CascadeClassifier
 // =============================================================================
-void* cv_cascade_classifier_new() { return new cv::CascadeClassifier(); }
+void* cv_cascade_classifier_new() {
+    return new cv::CascadeClassifier();
+}
 
 bool cv_cascade_classifier_load(cv::CascadeClassifier* cascade,
                                 const char* const p) {
@@ -370,18 +457,27 @@ void cv_cascade_classifier_drop(cv::CascadeClassifier* cascade) {
 }
 
 void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade,
-                                  cv::Mat* image, CVec<Rect>* vec_of_rect,
-                                  double scale_factor, int min_neighbors,
-                                  int flags, Size2i min_size, Size2i max_size) {
+                                  cv::Mat* image,
+                                  CVec<Rect>* vec_of_rect,
+                                  double scale_factor,
+                                  int min_neighbors,
+                                  int flags,
+                                  Size2i min_size,
+                                  Size2i max_size) {
     std::vector<cv::Rect> objects;
 
     cv::Size cv_min_size(min_size.width, min_size.height);
     cv::Size cv_max_size(max_size.width, max_size.height);
-    cascade->detectMultiScale(*image, objects, scale_factor, min_neighbors,
-                              flags, cv_min_size, cv_max_size);
+    cascade->detectMultiScale(*image,
+                              objects,
+                              scale_factor,
+                              min_neighbors,
+                              flags,
+                              cv_min_size,
+                              cv_max_size);
     // Move objects to vec_of_rect
     size_t num = objects.size();
-    vec_of_rect->array = (Rect*)malloc(num * sizeof(Rect));
+    vec_of_rect->array = (Rect*) malloc(num * sizeof(Rect));
     vec_of_rect->size = num;
     for (size_t i = 0; i < num; i++) {
         vec_of_rect->array[i].x = objects[i].x;
@@ -406,7 +502,9 @@ void cv_hog_detector_drop(std::vector<float>* detector) {
     detector = nullptr;
 }
 
-void* cv_hog_new() { return new cv::HOGDescriptor(); }
+void* cv_hog_new() {
+    return new cv::HOGDescriptor();
+}
 
 void cv_hog_drop(cv::HOGDescriptor* hog) {
     delete hog;
@@ -415,13 +513,18 @@ void cv_hog_drop(cv::HOGDescriptor* hog) {
 
 void cv_hog_set_svm_detector(cv::HOGDescriptor* hog,
                              std::vector<float>* detector) {
-
     hog->setSVMDetector(*detector);
 }
 
-void cv_hog_detect(cv::HOGDescriptor* hog, cv::Mat* image, CVec<Rect>* vec_rect,
-                   CVec<double>* vec_weight, Size2i win_stride, Size2i padding,
-                   double scale, double final_threshold, bool use_means_shift) {
+void cv_hog_detect(cv::HOGDescriptor* hog,
+                   cv::Mat* image,
+                   CVec<Rect>* vec_rect,
+                   CVec<double>* vec_weight,
+                   Size2i win_stride,
+                   Size2i padding,
+                   double scale,
+                   double final_threshold,
+                   bool use_means_shift) {
     // convert all types
 
     std::vector<cv::Rect> objects;
@@ -430,8 +533,15 @@ void cv_hog_detect(cv::HOGDescriptor* hog, cv::Mat* image, CVec<Rect>* vec_rect,
     cv::Size cv_padding(padding.width, padding.height);
 
     // Call the function
-    hog->detectMultiScale(*image, objects, weights, 0.1, cv_win_stride,
-                          cv_padding, scale, final_threshold, use_means_shift);
+    hog->detectMultiScale(*image,
+                          objects,
+                          weights,
+                          0.1,
+                          cv_win_stride,
+                          cv_padding,
+                          scale,
+                          final_threshold,
+                          use_means_shift);
 
     // Prepare the results
     cv_to_ffi(objects, vec_rect);
@@ -450,8 +560,7 @@ void cv_term_criteria_drop(cv::TermCriteria* criteria) {
     criteria = nullptr;
 }
 
-RotatedRect cv_camshift(cv::Mat* bp_image, Rect crect,
-                        cv::TermCriteria* criteria) {
+RotatedRect cv_camshift(cv::Mat* bp_image, Rect crect, cv::TermCriteria* criteria) {
     cv::Rect rect(crect.x, crect.y, crect.width, crect.height);
     cv::RotatedRect rr = cv::CamShift(*bp_image, rect, *criteria);
     RotatedRect c_rr;
@@ -467,13 +576,24 @@ RotatedRect cv_camshift(cv::Mat* bp_image, Rect crect,
 //   MSER
 // =============================================================================
 
-void* cv_mser_new(int delta, int min_area, int max_area, double max_variation,
-                  double min_diversity, int max_evolution,
-                  double area_threshold, double min_margin,
+void* cv_mser_new(int delta,
+                  int min_area,
+                  int max_area,
+                  double max_variation,
+                  double min_diversity,
+                  int max_evolution,
+                  double area_threshold,
+                  double min_margin,
                   int edge_blur_size) {
-    cv::Ptr<cv::MSER> result = cv::MSER::create(
-        delta, min_area, max_area, max_variation, min_diversity, max_evolution,
-        area_threshold, min_margin, edge_blur_size);
+    cv::Ptr<cv::MSER> result = cv::MSER::create(delta,
+                                                min_area,
+                                                max_area,
+                                                max_variation,
+                                                min_diversity,
+                                                max_evolution,
+                                                area_threshold,
+                                                min_margin,
+                                                edge_blur_size);
     return new cv::Ptr<cv::MSER>(result);
 }
 
@@ -482,8 +602,10 @@ void cv_mser_drop(cv::Ptr<cv::MSER>* detector) {
     detector = nullptr;
 }
 
-void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
-                            CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes) {
+void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector,
+                            cv::Mat* image,
+                            CVec<CVec<Point2i>>* msers,
+                            CVec<Rect>* bboxes) {
     std::vector<std::vector<cv::Point>> msers_vector;
     std::vector<cv::Rect> bboxes_vector;
 
@@ -493,18 +615,23 @@ void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
     cv_to_ffi(bboxes_vector, bboxes);
 }
 
-void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
-                                cv::Mat* mask, CVec<KeyPoint>* keypoints,
+void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
                                 cv::Mat* descriptors,
                                 bool useProvidedKeypoints) {
     std::vector<cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
-                                      *descriptors, useProvidedKeypoints);
+    detector->get()->detectAndCompute(
+        *image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void* cv_surf_new(double hessianThreshold, int nOctaves, int nOctaveLayers,
-                  bool extended, bool upright) {
+void* cv_surf_new(double hessianThreshold,
+                  int nOctaves,
+                  int nOctaveLayers,
+                  bool extended,
+                  bool upright) {
     auto result = cv::xfeatures2d::SURF::create(
         hessianThreshold, nOctaves, nOctaveLayers, extended, upright);
     return new cv::Ptr<cv::xfeatures2d::SURF>(result);
@@ -515,17 +642,22 @@ void cv_surf_drop(cv::Ptr<cv::xfeatures2d::SURF>* detector) {
 }
 
 void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector,
-                                cv::Mat* image, cv::Mat* mask,
-                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
                                 bool useProvidedKeypoints) {
     std::vector<cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
-                                      *descriptors, useProvidedKeypoints);
+    detector->get()->detectAndCompute(
+        *image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void* cv_sift_new(int nfeatures, int nOctaveLayers, double contrastThreshold,
-                  double edgeThreshold, double sigma) {
+void* cv_sift_new(int nfeatures,
+                  int nOctaveLayers,
+                  double contrastThreshold,
+                  double edgeThreshold,
+                  double sigma) {
     auto result = cv::xfeatures2d::SIFT::create(
         nfeatures, nOctaveLayers, contrastThreshold, edgeThreshold, sigma);
     return new cv::Ptr<cv::xfeatures2d::SIFT>(result);
@@ -536,16 +668,20 @@ void cv_sift_drop(cv::Ptr<cv::xfeatures2d::SIFT>* detector) {
 }
 
 void cv_sift_detect_and_compute(cv::Ptr<cv::xfeatures2d::SIFT>* detector,
-                                cv::Mat* image, cv::Mat* mask,
-                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
                                 bool useProvidedKeypoints) {
     std::vector<cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
-                                      *descriptors, useProvidedKeypoints);
+    detector->get()->detectAndCompute(
+        *image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method,
+void cv_compare_hist(cv::Mat* first_image,
+                     cv::Mat* second_image,
+                     int method,
                      Result<double>* result) {
     *result =
         Result<double>::FromFunction([first_image, second_image, method]() {

--- a/native/opencv-wrapper.cc
+++ b/native/opencv-wrapper.cc
@@ -2,11 +2,11 @@
 #include "utils.h"
 
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/objdetect.hpp>
 #include <opencv2/video/tracking.hpp>
-#include <opencv2/features2d.hpp>
 #include <opencv2/xfeatures2d.hpp>
 
 EXTERN_C_BEGIN
@@ -30,14 +30,11 @@ void* cv_mat_zeros(int rows, int cols, int type) {
 }
 
 void* cv_mat_from_buffer(int rows, int cols, int type, const uint8_t* buf) {
-    return (
-        new cv::Mat(rows, cols, type,
-                    const_cast<void*>(reinterpret_cast<const void*>(buf))));
+    return (new cv::Mat(rows, cols, type,
+                        const_cast<void*>(reinterpret_cast<const void*>(buf))));
 }
 
-bool cv_mat_is_valid(cv::Mat* mat) {
-    return mat->data != NULL;
-}
+bool cv_mat_is_valid(cv::Mat* mat) { return mat->data != NULL; }
 
 void* cv_mat_roi(cv::Mat* mat, Rect crect) {
     cv::Rect rect(crect.x, crect.y, crect.width, crect.height);
@@ -49,9 +46,7 @@ void cv_mat_logic_and(cv::Mat* image, const cv::Mat* const mask) {
     (*image) &= (*mask);
 }
 
-void cv_mat_flip(cv::Mat* image, int code) {
-    cv::flip(*image, *image, code);
-}
+void cv_mat_flip(cv::Mat* image, int code) { cv::flip(*image, *image, code); }
 
 void* cv_imread(const char* const filename, int flags) {
     cv::Mat* image = new cv::Mat();
@@ -59,45 +54,25 @@ void* cv_imread(const char* const filename, int flags) {
     return (image);
 }
 
-int cv_mat_cols(const cv::Mat* const mat) {
-    return mat->cols;
-}
+int cv_mat_cols(const cv::Mat* const mat) { return mat->cols; }
 
-int cv_mat_rows(const cv::Mat* const mat) {
-    return mat->rows;
-}
+int cv_mat_rows(const cv::Mat* const mat) { return mat->rows; }
 
-int cv_mat_depth(const cv::Mat* const mat) {
-    return mat->depth();
-}
+int cv_mat_depth(const cv::Mat* const mat) { return mat->depth(); }
 
-int cv_mat_channels(const cv::Mat* const mat) {
-    return mat->channels();
-}
+int cv_mat_channels(const cv::Mat* const mat) { return mat->channels(); }
 
-int cv_mat_type(const cv::Mat* const mat) {
-    return mat->type();
-}
+int cv_mat_type(const cv::Mat* const mat) { return mat->type(); }
 
-const uint8_t* cv_mat_data(const cv::Mat* const mat) {
-    return mat->data;
-}
+const uint8_t* cv_mat_data(const cv::Mat* const mat) { return mat->data; }
 
-size_t cv_mat_total(const cv::Mat* const mat) {
-    return mat->total();
-}
+size_t cv_mat_total(const cv::Mat* const mat) { return mat->total(); }
 
-size_t cv_mat_elem_size(const cv::Mat* const mat) {
-    return mat->elemSize();
-}
+size_t cv_mat_elem_size(const cv::Mat* const mat) { return mat->elemSize(); }
 
-size_t cv_mat_elem_size1(const cv::Mat* const mat) {
-    return mat->elemSize1();
-}
+size_t cv_mat_elem_size1(const cv::Mat* const mat) { return mat->elemSize1(); }
 
-size_t cv_mat_step1(const cv::Mat* const mat, int i) {
-    return mat->step1(i);
-}
+size_t cv_mat_step1(const cv::Mat* const mat, int i) { return mat->step1(i); }
 
 void cv_mat_drop(cv::Mat* mat) {
     delete mat;
@@ -107,7 +82,7 @@ void cv_mat_drop(cv::Mat* mat) {
 void cv_vec_drop(CVec<void>* vec, unsigned int depth) {
     if (vec->array != nullptr) {
         if (depth > 1) {
-            auto nestedVec = (CVec<void>*) vec->array;
+            auto nestedVec = (CVec<void>*)vec->array;
             for (size_t i = 0; i < vec->size; ++i) {
                 cv_vec_drop(&nestedVec[i], depth - 1);
             }
@@ -118,8 +93,7 @@ void cv_vec_drop(CVec<void>* vec, unsigned int depth) {
     }
 }
 
-void c_drop(void* value)
-{
+void c_drop(void* value) {
     free(value);
     value = nullptr;
 }
@@ -135,8 +109,7 @@ void cv_in_range(cv::Mat* mat, Scalar lowerb, Scalar upperb, cv::Mat* dst) {
 
 void cv_min_max_loc(const cv::Mat* const mat, double* min, double* max,
                     Point2i* minLoc, Point2i* maxLoc,
-                    const cv::Mat* const mask)
-{
+                    const cv::Mat* const mask) {
     if (minLoc == NULL && maxLoc == NULL) {
         cv::minMaxLoc(*mat, min, max, NULL, NULL, *mask);
     } else if (minLoc == NULL && maxLoc != NULL) {
@@ -161,25 +134,21 @@ void cv_min_max_loc(const cv::Mat* const mat, double* min, double* max,
 }
 
 void cv_mix_channels(cv::Mat* src, size_t nsrcs, cv::Mat* dst, size_t ndsts,
-                     const int* from_to, size_t npairs)
-{
+                     const int* from_to, size_t npairs) {
     cv::mixChannels(src, nsrcs, dst, ndsts, from_to, npairs);
 }
 
 void cv_normalize(cv::Mat* src, cv::Mat* dst, double alpha, double beta,
-                  int norm_type)
-{
+                  int norm_type) {
     cv::normalize(*src, *dst, alpha, beta, norm_type);
 }
 
 void cv_bitwise_and(const cv::Mat* const src1, const cv::Mat* const src2,
-                    cv::Mat* dst)
-{
+                    cv::Mat* dst) {
     cv::bitwise_and(*src1, *src2, *dst);
 }
 
-void cv_bitwise_not(const cv::Mat* const src, cv::Mat* const dst)
-{
+void cv_bitwise_not(const cv::Mat* const src, cv::Mat* const dst) {
     cv::bitwise_not(*src, *dst);
 }
 
@@ -230,9 +199,7 @@ void cv_cvt_color(cv::Mat* mat, cv::Mat* out, int code) {
     cv::cvtColor(*mat, *out, code);
 }
 
-void cv_pyr_down(cv::Mat* mat, cv::Mat* out) {
-    cv::pyrDown(*mat, *out);
-}
+void cv_pyr_down(cv::Mat* mat, cv::Mat* out) { cv::pyrDown(*mat, *out); }
 
 void cv_resize(cv::Mat* from, cv::Mat* to, Size2i dsize, double fx, double fy,
                int interpolation) {
@@ -241,8 +208,8 @@ void cv_resize(cv::Mat* from, cv::Mat* to, Size2i dsize, double fx, double fy,
 }
 
 void cv_calc_hist(const cv::Mat* images, int nimages, const int* channels,
-                  cv::Mat* mask, cv::Mat* hist, int dims,
-                  const int* hist_size, const float** ranges) {
+                  cv::Mat* mask, cv::Mat* hist, int dims, const int* hist_size,
+                  const float** ranges) {
     cv::calcHist(images, nimages, channels, *mask, *hist, dims, hist_size,
                  ranges);
 }
@@ -294,14 +261,12 @@ void cv_destroy_window(const char* const winname) {
 }
 
 void cv_imshow(const char* const winname, cv::Mat* mat) {
-        if (mat != NULL) {
+    if (mat != NULL) {
         cv::imshow(winname, *mat);
     }
 }
 
-int cv_wait_key(int delay) {
-    return cv::waitKey(delay);
-}
+int cv_wait_key(int delay) { return cv::waitKey(delay); }
 
 void cv_set_mouse_callback(const char* const winname, MouseCallback on_mouse,
                            void* userdata) {
@@ -311,9 +276,7 @@ void cv_set_mouse_callback(const char* const winname, MouseCallback on_mouse,
 // =============================================================================
 //   VideoCapture
 // =============================================================================
-void* cv_videocapture_new(int index) {
-    return new cv::VideoCapture(index);
-}
+void* cv_videocapture_new(int index) { return new cv::VideoCapture(index); }
 
 void* cv_videocapture_from_file(const char* const filename) {
     return new cv::VideoCapture(filename);
@@ -345,16 +308,14 @@ double cv_videocapture_get(cv::VideoCapture* cap, int property) {
 // =============================================================================
 /// http://www.fourcc.org/codecs.php
 int cv_fourcc(char c1, char c2, char c3, char c4) {
-    return (((c1) &255) + (((c2) &255) << 8) + (((c3) &255) << 16) +
-            (((c4) &255) << 24));
+    return (((c1)&255) + (((c2)&255) << 8) + (((c3)&255) << 16) +
+            (((c4)&255) << 24));
 }
 
-void* cv_videowriter_default() {
-    return new cv::VideoWriter();
-}
+void* cv_videowriter_default() { return new cv::VideoWriter(); }
 
 void* cv_videowriter_new(const char* const path, int fourcc, double fps,
-                                 Size2i frame_size, bool is_color) {
+                         Size2i frame_size, bool is_color) {
     cv::Size cv_frame_size(frame_size.width, frame_size.height);
     cv::VideoWriter* writer =
         new cv::VideoWriter(path, fourcc, fps, cv_frame_size, is_color);
@@ -392,11 +353,10 @@ double cv_videowriter_get(cv::VideoWriter* writer, int property) {
 // =============================================================================
 //   CascadeClassifier
 // =============================================================================
-void* cv_cascade_classifier_new() {
-    return new cv::CascadeClassifier();
-}
+void* cv_cascade_classifier_new() { return new cv::CascadeClassifier(); }
 
-bool cv_cascade_classifier_load(cv::CascadeClassifier* cascade, const char* const p) {
+bool cv_cascade_classifier_load(cv::CascadeClassifier* cascade,
+                                const char* const p) {
     return cascade->load(p);
 }
 
@@ -409,10 +369,10 @@ void cv_cascade_classifier_drop(cv::CascadeClassifier* cascade) {
     cascade = nullptr;
 }
 
-void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade, cv::Mat* image,
-                                  CVec<Rect>* vec_of_rect, double scale_factor,
-                                  int min_neighbors, int flags, Size2i min_size,
-                                  Size2i max_size) {
+void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade,
+                                  cv::Mat* image, CVec<Rect>* vec_of_rect,
+                                  double scale_factor, int min_neighbors,
+                                  int flags, Size2i min_size, Size2i max_size) {
     std::vector<cv::Rect> objects;
 
     cv::Size cv_min_size(min_size.width, min_size.height);
@@ -421,7 +381,7 @@ void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade, cv::Mat* image
                               flags, cv_min_size, cv_max_size);
     // Move objects to vec_of_rect
     size_t num = objects.size();
-    vec_of_rect->array = (Rect*) malloc(num * sizeof(Rect));
+    vec_of_rect->array = (Rect*)malloc(num * sizeof(Rect));
     vec_of_rect->size = num;
     for (size_t i = 0; i < num; i++) {
         vec_of_rect->array[i].x = objects[i].x;
@@ -432,11 +392,13 @@ void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade, cv::Mat* image
 }
 
 void* cv_hog_default_people_detector() {
-    return new std::vector<float>(cv::HOGDescriptor::getDefaultPeopleDetector());
+    return new std::vector<float>(
+        cv::HOGDescriptor::getDefaultPeopleDetector());
 }
 
 void* cv_hog_daimler_people_detector() {
-    return new std::vector<float>(cv::HOGDescriptor::getDaimlerPeopleDetector());
+    return new std::vector<float>(
+        cv::HOGDescriptor::getDaimlerPeopleDetector());
 }
 
 void cv_hog_detector_drop(std::vector<float>* detector) {
@@ -444,16 +406,15 @@ void cv_hog_detector_drop(std::vector<float>* detector) {
     detector = nullptr;
 }
 
-void* cv_hog_new() {
-    return new cv::HOGDescriptor();
-}
+void* cv_hog_new() { return new cv::HOGDescriptor(); }
 
 void cv_hog_drop(cv::HOGDescriptor* hog) {
     delete hog;
     hog = nullptr;
 }
 
-void cv_hog_set_svm_detector(cv::HOGDescriptor* hog, std::vector<float>* detector) {
+void cv_hog_set_svm_detector(cv::HOGDescriptor* hog,
+                             std::vector<float>* detector) {
 
     hog->setSVMDetector(*detector);
 }
@@ -463,7 +424,6 @@ void cv_hog_detect(cv::HOGDescriptor* hog, cv::Mat* image, CVec<Rect>* vec_rect,
                    double scale, double final_threshold, bool use_means_shift) {
     // convert all types
 
-
     std::vector<cv::Rect> objects;
     std::vector<double> weights;
     cv::Size cv_win_stride(win_stride.width, win_stride.height);
@@ -471,8 +431,7 @@ void cv_hog_detect(cv::HOGDescriptor* hog, cv::Mat* image, CVec<Rect>* vec_rect,
 
     // Call the function
     hog->detectMultiScale(*image, objects, weights, 0.1, cv_win_stride,
-                             cv_padding, scale, final_threshold,
-                             use_means_shift);
+                          cv_padding, scale, final_threshold, use_means_shift);
 
     // Prepare the results
     cv_to_ffi(objects, vec_rect);
@@ -508,24 +467,13 @@ RotatedRect cv_camshift(cv::Mat* bp_image, Rect crect,
 //   MSER
 // =============================================================================
 
-void* cv_mser_new(int delta,
-                   int min_area,
-                   int max_area,
-                   double max_variation,
-                   double min_diversity,
-                   int max_evolution,
-                   double area_threshold,
-                   double min_margin,
-                   int edge_blur_size) {
-    cv::Ptr<cv::MSER> result = cv::MSER::create(delta,
-                                                min_area,
-                                                max_area,
-                                                max_variation,
-                                                min_diversity,
-                                                max_evolution,
-                                                area_threshold,
-                                                min_margin,
-                                                edge_blur_size);
+void* cv_mser_new(int delta, int min_area, int max_area, double max_variation,
+                  double min_diversity, int max_evolution,
+                  double area_threshold, double min_margin,
+                  int edge_blur_size) {
+    cv::Ptr<cv::MSER> result = cv::MSER::create(
+        delta, min_area, max_area, max_variation, min_diversity, max_evolution,
+        area_threshold, min_margin, edge_blur_size);
     return new cv::Ptr<cv::MSER>(result);
 }
 
@@ -534,7 +482,8 @@ void cv_mser_drop(cv::Ptr<cv::MSER>* detector) {
     detector = nullptr;
 }
 
-void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image, CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes) {
+void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
+                            CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes) {
     std::vector<std::vector<cv::Point>> msers_vector;
     std::vector<cv::Rect> bboxes_vector;
 
@@ -544,65 +493,64 @@ void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image, CVec<CV
     cv_to_ffi(bboxes_vector, bboxes);
 }
 
-void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,  cv::Mat* mask, CVec<KeyPoint>* keypoints, cv::Mat* descriptors, bool useProvidedKeypoints) {
+void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
+                                cv::Mat* mask, CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
+                                bool useProvidedKeypoints) {
     std::vector<cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
+    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
+                                      *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void* cv_surf_new(double hessianThreshold,
-                  int nOctaves,
-                  int nOctaveLayers,
-                  bool extended,
-                  bool upright
-) {
-    auto result = cv::xfeatures2d::SURF::create(hessianThreshold,
-                                                nOctaves,
-                                                nOctaveLayers,
-                                                extended,
-                                                upright);
+void* cv_surf_new(double hessianThreshold, int nOctaves, int nOctaveLayers,
+                  bool extended, bool upright) {
+    auto result = cv::xfeatures2d::SURF::create(
+        hessianThreshold, nOctaves, nOctaveLayers, extended, upright);
     return new cv::Ptr<cv::xfeatures2d::SURF>(result);
 }
-void cv_surf_drop(cv::Ptr <cv::xfeatures2d::SURF>* detector) {
+void cv_surf_drop(cv::Ptr<cv::xfeatures2d::SURF>* detector) {
     delete detector;
     detector = nullptr;
 }
 
-void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector, cv::Mat* image,  cv::Mat* mask, CVec<KeyPoint>* keypoints, cv::Mat* descriptors, bool useProvidedKeypoints) {
+void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector,
+                                cv::Mat* image, cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                bool useProvidedKeypoints) {
     std::vector<cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
+    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
+                                      *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void *cv_sift_new(int nfeatures,
-                  int nOctaveLayers,
-                  double contrastThreshold,
-                  double edgeThreshold,
-                  double sigma
-) {
-    auto result = cv::xfeatures2d::SIFT::create(nfeatures,
-                                                nOctaveLayers,
-                                                contrastThreshold,
-                                                edgeThreshold,
-                                                sigma);
+void* cv_sift_new(int nfeatures, int nOctaveLayers, double contrastThreshold,
+                  double edgeThreshold, double sigma) {
+    auto result = cv::xfeatures2d::SIFT::create(
+        nfeatures, nOctaveLayers, contrastThreshold, edgeThreshold, sigma);
     return new cv::Ptr<cv::xfeatures2d::SIFT>(result);
 }
-void cv_sift_drop(cv::Ptr <cv::xfeatures2d::SIFT> *detector) {
+void cv_sift_drop(cv::Ptr<cv::xfeatures2d::SIFT>* detector) {
     delete detector;
     detector = nullptr;
 }
 
-void cv_sift_detect_and_compute(cv::Ptr <cv::xfeatures2d::SIFT> *detector, cv::Mat *image, cv::Mat *mask,
-                                CVec<KeyPoint> *keypoints, cv::Mat *descriptors, bool useProvidedKeypoints) {
-    std::vector <cv::KeyPoint> keypoints_vector;
-    detector->get()->detectAndCompute(*image, *mask, keypoints_vector, *descriptors, useProvidedKeypoints);
+void cv_sift_detect_and_compute(cv::Ptr<cv::xfeatures2d::SIFT>* detector,
+                                cv::Mat* image, cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                bool useProvidedKeypoints) {
+    std::vector<cv::KeyPoint> keypoints_vector;
+    detector->get()->detectAndCompute(*image, *mask, keypoints_vector,
+                                      *descriptors, useProvidedKeypoints);
     cv_to_ffi(keypoints_vector, keypoints);
 }
 
-void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method, Result<double>* result) {
-    *result = Result<double>::FromFunction([first_image, second_image, method](){
-        return cv::compareHist(*first_image, *second_image, method);
-    });
+void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method,
+                     Result<double>* result) {
+    *result =
+        Result<double>::FromFunction([first_image, second_image, method]() {
+            return cv::compareHist(*first_image, *second_image, method);
+        });
 }
 
 EXTERN_C_END

--- a/native/opencv-wrapper.cc
+++ b/native/opencv-wrapper.cc
@@ -560,7 +560,8 @@ void cv_term_criteria_drop(cv::TermCriteria* criteria) {
     criteria = nullptr;
 }
 
-RotatedRect cv_camshift(cv::Mat* bp_image, Rect crect, cv::TermCriteria* criteria) {
+RotatedRect
+cv_camshift(cv::Mat* bp_image, Rect crect, cv::TermCriteria* criteria) {
     cv::Rect rect(crect.x, crect.y, crect.width, crect.height);
     cv::RotatedRect rr = cv::CamShift(*bp_image, rect, *criteria);
     RotatedRect c_rr;

--- a/native/opencv-wrapper.h
+++ b/native/opencv-wrapper.h
@@ -1,17 +1,17 @@
 #ifndef OPENCV_WRAPPER_H_
 #define OPENCV_WRAPPER_H_
 
+#include "common.h"
+#include <functional>
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/objdetect.hpp>
 #include <opencv2/video/tracking.hpp>
-#include <opencv2/features2d.hpp>
 #include <opencv2/xfeatures2d.hpp>
-#include <functional>
 #include <stddef.h>
 #include <stdint.h>
-#include "common.h"
 
 #define EXTERN_C_BEGIN extern "C" {
 #define EXTERN_C_END }
@@ -128,7 +128,7 @@ int cv_fourcc(char c1, char c2, char c3, char c4);
 
 void* cv_videowriter_default();
 void* cv_videowriter_new(const char* const path, int fourcc, double fps,
-                                 Size2i frame_size, bool is_color);
+                         Size2i frame_size, bool is_color);
 void cv_videowriter_drop(cv::VideoWriter* writer);
 bool cv_videowriter_open(cv::VideoWriter* writer, const char* const path,
                          int fourcc, double fps, Size2i frame_size,
@@ -143,7 +143,8 @@ double cv_videowriter_get(cv::VideoWriter* writer, int property);
 // =============================================================================
 void* cv_cascade_classifier_new();
 void* cv_cascade_classifier_from_path(const char* const path);
-bool cv_cascade_classifier_load(cv::CascadeClassifier* cc, const char* const path);
+bool cv_cascade_classifier_load(cv::CascadeClassifier* cc,
+                                const char* const path);
 void cv_cascade_classifier_drop(cv::CascadeClassifier* cc);
 
 // vec_of_rect is dynamically allocated, the caller should take ownership of it.
@@ -174,53 +175,48 @@ RotatedRect cv_camshift(cv::Mat* back_project_image, Rect window,
 // =============================================================================
 //   MSER
 // =============================================================================
-void* cv_mser_new(int delta,
-                  int min_area,
-                  int max_area,
-                  double max_variation,
-                  double min_diversity,
-                  int max_evolution,
-                  double area_threshold,
-                  double min_margin,
-                  int edge_blur_size);
+void* cv_mser_new(int delta, int min_area, int max_area, double max_variation,
+                  double min_diversity, int max_evolution,
+                  double area_threshold, double min_margin, int edge_blur_size);
 void cv_mser_drop(cv::Ptr<cv::MSER>* detector);
-void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image, CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes);
-void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,  cv::Mat* mask, CVec<KeyPoint>* keypoints, cv::Mat* descriptors, bool useProvidedKeypoints);
+void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
+                            CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes);
+void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
+                                cv::Mat* mask, CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
+                                bool useProvidedKeypoints);
 
 // =============================================================================
 //   SURF
 // =============================================================================
 
-void* cv_surf_new(double hessianThreshold,
-                  int nOctaves,
-                  int nOctaveLayers,
-                  bool extended,
-                  bool upright
-);
-void cv_surf_drop(cv::Ptr <cv::xfeatures2d::SURF> *detector);
-void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector, cv::Mat* image,  cv::Mat* mask, CVec<KeyPoint>* keypoints, cv::Mat* descriptors, bool useProvidedKeypoints);
-
+void* cv_surf_new(double hessianThreshold, int nOctaves, int nOctaveLayers,
+                  bool extended, bool upright);
+void cv_surf_drop(cv::Ptr<cv::xfeatures2d::SURF>* detector);
+void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector,
+                                cv::Mat* image, cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                bool useProvidedKeypoints);
 
 // =============================================================================
 //   SIFT
 // =============================================================================
 
-void *cv_sift_new(int nfeatures,
-                  int nOctaveLayers,
-                  double contrastThreshold,
-                  double edgeThreshold,
-                  double sigma
-);
-void cv_sift_drop(cv::Ptr <cv::xfeatures2d::SIFT> *detector);
-void cv_sift_detect_and_compute(cv::Ptr <cv::xfeatures2d::SIFT> *detector, cv::Mat *image, cv::Mat *mask,
-                                CVec<KeyPoint> *keypoints, cv::Mat *descriptors, bool useProvidedKeypoints);
+void* cv_sift_new(int nfeatures, int nOctaveLayers, double contrastThreshold,
+                  double edgeThreshold, double sigma);
+void cv_sift_drop(cv::Ptr<cv::xfeatures2d::SIFT>* detector);
+void cv_sift_detect_and_compute(cv::Ptr<cv::xfeatures2d::SIFT>* detector,
+                                cv::Mat* image, cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                bool useProvidedKeypoints);
 
 // =============================================================================
 //   Other
 // =============================================================================
 
-void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method, Result<double>* result);
+void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method,
+                     Result<double>* result);
 
 EXTERN_C_END
 
-#endif  // OPENCV_WRAPPER_H_
+#endif // OPENCV_WRAPPER_H_

--- a/native/opencv-wrapper.h
+++ b/native/opencv-wrapper.h
@@ -1,7 +1,6 @@
 #ifndef OPENCV_WRAPPER_H_
 #define OPENCV_WRAPPER_H_
 
-#include "common.h"
 #include <functional>
 #include <opencv2/core.hpp>
 #include <opencv2/features2d.hpp>
@@ -12,6 +11,8 @@
 #include <opencv2/xfeatures2d.hpp>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "common.h"
 
 #define EXTERN_C_BEGIN extern "C" {
 #define EXTERN_C_END }

--- a/native/opencv-wrapper.h
+++ b/native/opencv-wrapper.h
@@ -57,50 +57,86 @@ void c_drop(void* value);
 //  core array
 // =============================================================================
 void cv_in_range(cv::Mat* mat, Scalar lowerb, Scalar upperb, cv::Mat* dst);
-void cv_min_max_loc(const cv::Mat* const mat, double* min, double* max,
-                    Point2i* minLoc, Point2i* maxLoc,
+void cv_min_max_loc(const cv::Mat* const mat,
+                    double* min,
+                    double* max,
+                    Point2i* minLoc,
+                    Point2i* maxLoc,
                     const cv::Mat* const cmask);
-void cv_mix_channels(cv::Mat* mat, size_t nsrcs, cv::Mat* dst, size_t ndsts,
-                     const int* from_to, size_t npairs);
-void cv_normalize(cv::Mat* csrc, cv::Mat* cdst, double alpha, double beta,
-                  int norm_type);
-void cv_bitwise_and(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_mix_channels(cv::Mat* mat,
+                     size_t nsrcs,
+                     cv::Mat* dst,
+                     size_t ndsts,
+                     const int* from_to,
+                     size_t npairs);
+void cv_normalize(
+    cv::Mat* csrc, cv::Mat* cdst, double alpha, double beta, int norm_type);
+void cv_bitwise_and(const cv::Mat* const src1,
+                    const cv::Mat* const src2,
                     cv::Mat* dst);
 void cv_bitwise_not(const cv::Mat* const src, cv::Mat* const dst);
-void cv_bitwise_or(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_bitwise_or(const cv::Mat* const src1,
+                   const cv::Mat* const src2,
                    cv::Mat* dst);
-void cv_bitwise_xor(const cv::Mat* const src1, const cv::Mat* const src2,
+void cv_bitwise_xor(const cv::Mat* const src1,
+                    const cv::Mat* const src2,
                     cv::Mat* dst);
 int cv_count_non_zero(const cv::Mat* const src);
 
 // =============================================================================
 //  Imgproc
 // =============================================================================
-void cv_line(cv::Mat* mat, Point2i pt1, Point2i pt2, Scalar color,
-             int thickness, int linetype, int shift);
-void cv_rectangle(cv::Mat* mat, Rect crect, Scalar color, int thickness,
-                  int linetype);
-void cv_ellipse(cv::Mat* mat, Point2i center, Size2i axes, double angle,
-                double start_angle, double end_angle, Scalar color,
-                int thickness, int linetype, int shift);
+void cv_line(cv::Mat* mat,
+             Point2i pt1,
+             Point2i pt2,
+             Scalar color,
+             int thickness,
+             int linetype,
+             int shift);
+void cv_rectangle(
+    cv::Mat* mat, Rect crect, Scalar color, int thickness, int linetype);
+void cv_ellipse(cv::Mat* mat,
+                Point2i center,
+                Size2i axes,
+                double angle,
+                double start_angle,
+                double end_angle,
+                Scalar color,
+                int thickness,
+                int linetype,
+                int shift);
 
 void cv_cvt_color(cv::Mat* mat, cv::Mat* output, int code);
 void cv_pyr_down(cv::Mat* mat, cv::Mat* output);
-void cv_resize(cv::Mat* from, cv::Mat* to, Size2i dsize, double fx, double fy,
+void cv_resize(cv::Mat* from,
+               cv::Mat* to,
+               Size2i dsize,
+               double fx,
+               double fy,
                int interpolation);
-void cv_calc_hist(const cv::Mat* const cimages, int nimages,
-                  const int* channels, cv::Mat* mask, cv::Mat* hist, int dims,
-                  const int* hist_size, const float** ranges);
-void cv_calc_back_project(const cv::Mat* images, int nimages,
-                          const int* channels, cv::Mat* hist,
-                          cv::Mat* back_project, const float** ranges);
+void cv_calc_hist(const cv::Mat* const cimages,
+                  int nimages,
+                  const int* channels,
+                  cv::Mat* mask,
+                  cv::Mat* hist,
+                  int dims,
+                  const int* hist_size,
+                  const float** ranges);
+void cv_calc_back_project(const cv::Mat* images,
+                          int nimages,
+                          const int* channels,
+                          cv::Mat* hist,
+                          cv::Mat* back_project,
+                          const float** ranges);
 
 // =============================================================================
 //  Imgcodecs
 // =============================================================================
 void* cv_imdecode(const uint8_t* const buffer, size_t len, int flag);
-ImencodeResult cv_imencode(const char* const ext, const cv::Mat* const mat,
-                           const int* const flag_ptr, size_t flag_size);
+ImencodeResult cv_imencode(const char* const ext,
+                           const cv::Mat* const mat,
+                           const int* const flag_ptr,
+                           size_t flag_size);
 
 // =============================================================================
 //   Highgui: high-level GUI
@@ -111,7 +147,8 @@ void cv_imshow(const char* const winname, cv::Mat* mat);
 int cv_wait_key(int delay_in_millis);
 
 typedef void (*MouseCallback)(int e, int x, int y, int flags, void* data);
-void cv_set_mouse_callback(const char* const winname, MouseCallback onMouse,
+void cv_set_mouse_callback(const char* const winname,
+                           MouseCallback onMouse,
                            void* userdata);
 
 // =============================================================================
@@ -128,11 +165,17 @@ double cv_videocapture_get(cv::VideoCapture* cap, int property);
 int cv_fourcc(char c1, char c2, char c3, char c4);
 
 void* cv_videowriter_default();
-void* cv_videowriter_new(const char* const path, int fourcc, double fps,
-                         Size2i frame_size, bool is_color);
+void* cv_videowriter_new(const char* const path,
+                         int fourcc,
+                         double fps,
+                         Size2i frame_size,
+                         bool is_color);
 void cv_videowriter_drop(cv::VideoWriter* writer);
-bool cv_videowriter_open(cv::VideoWriter* writer, const char* const path,
-                         int fourcc, double fps, Size2i frame_size,
+bool cv_videowriter_open(cv::VideoWriter* writer,
+                         const char* const path,
+                         int fourcc,
+                         double fps,
+                         Size2i frame_size,
                          bool is_color);
 bool cv_videowriter_is_opened(cv::VideoWriter* writer);
 void cv_videowriter_write(cv::VideoWriter* writer, cv::Mat* mat);
@@ -149,9 +192,13 @@ bool cv_cascade_classifier_load(cv::CascadeClassifier* cc,
 void cv_cascade_classifier_drop(cv::CascadeClassifier* cc);
 
 // vec_of_rect is dynamically allocated, the caller should take ownership of it.
-void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade, cv::Mat* mat,
-                                  CVec<Rect>* vec_of_rect, double scale_factor,
-                                  int min_neighbors, int flags, Size2i min_size,
+void cv_cascade_classifier_detect(cv::CascadeClassifier* cascade,
+                                  cv::Mat* mat,
+                                  CVec<Rect>* vec_of_rect,
+                                  double scale_factor,
+                                  int min_neighbors,
+                                  int flags,
+                                  Size2i min_size,
                                   Size2i max_size);
 
 void* cv_hog_default_people_detector();
@@ -161,29 +208,46 @@ void cv_hog_detector_drop(std::vector<float>*);
 void* cv_hog_new();
 void cv_hog_drop(cv::HOGDescriptor*);
 void cv_hog_set_svm_detector(cv::HOGDescriptor*, std::vector<float>*);
-void cv_hog_detect(cv::HOGDescriptor*, cv::Mat*, CVec<Rect>* vec_detected,
-                   CVec<double>* vec_weight, Size2i win_stride, Size2i padding,
-                   double scale, double final_threshold, bool use_means_shift);
+void cv_hog_detect(cv::HOGDescriptor*,
+                   cv::Mat*,
+                   CVec<Rect>* vec_detected,
+                   CVec<double>* vec_weight,
+                   Size2i win_stride,
+                   Size2i padding,
+                   double scale,
+                   double final_threshold,
+                   bool use_means_shift);
 
 // =============================================================================
 //   VideoTrack
 // =============================================================================
 void* cv_term_criteria_new(int type, int count, double epsilon);
 void cv_term_criteria_drop(cv::TermCriteria* criteria);
-RotatedRect cv_camshift(cv::Mat* back_project_image, Rect window,
+RotatedRect cv_camshift(cv::Mat* back_project_image,
+                        Rect window,
                         cv::TermCriteria* criteria);
 
 // =============================================================================
 //   MSER
 // =============================================================================
-void* cv_mser_new(int delta, int min_area, int max_area, double max_variation,
-                  double min_diversity, int max_evolution,
-                  double area_threshold, double min_margin, int edge_blur_size);
+void* cv_mser_new(int delta,
+                  int min_area,
+                  int max_area,
+                  double max_variation,
+                  double min_diversity,
+                  int max_evolution,
+                  double area_threshold,
+                  double min_margin,
+                  int edge_blur_size);
 void cv_mser_drop(cv::Ptr<cv::MSER>* detector);
-void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
-                            CVec<CVec<Point2i>>* msers, CVec<Rect>* bboxes);
-void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
-                                cv::Mat* mask, CVec<KeyPoint>* keypoints,
+void cv_mser_detect_regions(cv::Ptr<cv::MSER>* detector,
+                            cv::Mat* image,
+                            CVec<CVec<Point2i>>* msers,
+                            CVec<Rect>* bboxes);
+void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
                                 cv::Mat* descriptors,
                                 bool useProvidedKeypoints);
 
@@ -191,33 +255,45 @@ void cv_mser_detect_and_compute(cv::Ptr<cv::MSER>* detector, cv::Mat* image,
 //   SURF
 // =============================================================================
 
-void* cv_surf_new(double hessianThreshold, int nOctaves, int nOctaveLayers,
-                  bool extended, bool upright);
+void* cv_surf_new(double hessianThreshold,
+                  int nOctaves,
+                  int nOctaveLayers,
+                  bool extended,
+                  bool upright);
 void cv_surf_drop(cv::Ptr<cv::xfeatures2d::SURF>* detector);
 void cv_surf_detect_and_compute(cv::Ptr<cv::xfeatures2d::SURF>* detector,
-                                cv::Mat* image, cv::Mat* mask,
-                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
                                 bool useProvidedKeypoints);
 
 // =============================================================================
 //   SIFT
 // =============================================================================
 
-void* cv_sift_new(int nfeatures, int nOctaveLayers, double contrastThreshold,
-                  double edgeThreshold, double sigma);
+void* cv_sift_new(int nfeatures,
+                  int nOctaveLayers,
+                  double contrastThreshold,
+                  double edgeThreshold,
+                  double sigma);
 void cv_sift_drop(cv::Ptr<cv::xfeatures2d::SIFT>* detector);
 void cv_sift_detect_and_compute(cv::Ptr<cv::xfeatures2d::SIFT>* detector,
-                                cv::Mat* image, cv::Mat* mask,
-                                CVec<KeyPoint>* keypoints, cv::Mat* descriptors,
+                                cv::Mat* image,
+                                cv::Mat* mask,
+                                CVec<KeyPoint>* keypoints,
+                                cv::Mat* descriptors,
                                 bool useProvidedKeypoints);
 
 // =============================================================================
 //   Other
 // =============================================================================
 
-void cv_compare_hist(cv::Mat* first_image, cv::Mat* second_image, int method,
+void cv_compare_hist(cv::Mat* first_image,
+                     cv::Mat* second_image,
+                     int method,
                      Result<double>* result);
 
 EXTERN_C_END
 
-#endif // OPENCV_WRAPPER_H_
+#endif  // OPENCV_WRAPPER_H_

--- a/native/utils.cc
+++ b/native/utils.cc
@@ -1,10 +1,11 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
-#include "utils.h"
-#include "common.h"
 #include <opencv2/core.hpp>
 #include <vector>
+
+#include "common.h"
+#include "utils.h"
 
 void cv_to_ffi(const cv::Rect& source, Rect* dest) {
     dest->x = source.x;

--- a/native/utils.cc
+++ b/native/utils.cc
@@ -1,19 +1,19 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
-#include <vector>
-#include <opencv2/core.hpp>
-#include "common.h"
 #include "utils.h"
+#include "common.h"
+#include <opencv2/core.hpp>
+#include <vector>
 
-void cv_to_ffi(const cv::Rect& source, Rect* dest){
+void cv_to_ffi(const cv::Rect& source, Rect* dest) {
     dest->x = source.x;
     dest->y = source.y;
     dest->width = source.width;
     dest->height = source.height;
 }
 
-void cv_to_ffi(const cv::Point& source, Point2i* dest){
+void cv_to_ffi(const cv::Point& source, Point2i* dest) {
     dest->x = source.x;
     dest->y = source.y;
 };
@@ -31,16 +31,15 @@ void cv_to_ffi(const cv::KeyPoint& source, KeyPoint* dest) {
 void cv_to_ffi(const std::vector<double>& source, CVec<double>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (double*) malloc(num * sizeof(double));
+    dest->array = (double*)malloc(num * sizeof(double));
     ::memcpy(dest->array, source.data(), num * sizeof(double));
 }
 
 template <typename T, typename U>
-void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest)
-{
+void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (U*) malloc(num * sizeof(U));
+    dest->array = (U*)malloc(num * sizeof(U));
     for (size_t i = 0; i < num; i++) {
         cv_to_ffi(source[i], &dest->array[i]);
     }

--- a/native/utils.cc
+++ b/native/utils.cc
@@ -32,7 +32,7 @@ void cv_to_ffi(const cv::KeyPoint& source, KeyPoint* dest) {
 void cv_to_ffi(const std::vector<double>& source, CVec<double>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (double*)malloc(num * sizeof(double));
+    dest->array = (double*) malloc(num * sizeof(double));
     ::memcpy(dest->array, source.data(), num * sizeof(double));
 }
 
@@ -40,7 +40,7 @@ template <typename T, typename U>
 void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (U*)malloc(num * sizeof(U));
+    dest->array = (U*) malloc(num * sizeof(U));
     for (size_t i = 0; i < num; i++) {
         cv_to_ffi(source[i], &dest->array[i]);
     }

--- a/native/utils.h
+++ b/native/utils.h
@@ -1,9 +1,9 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
-#include <vector>
-#include <opencv2/core.hpp>
 #include "common.h"
+#include <opencv2/core.hpp>
+#include <vector>
 
 void cv_to_ffi(const cv::Rect& source, Rect* dest);
 void cv_to_ffi(const cv::Point& source, Point2i* dest);
@@ -11,13 +11,12 @@ void cv_to_ffi(const cv::KeyPoint& source, KeyPoint* dest);
 void cv_to_ffi(const std::vector<double>& source, CVec<double>* dest);
 
 template <typename T, typename U>
-void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest)
-{
+void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (U*) malloc(num * sizeof(U));
+    dest->array = (U*)malloc(num * sizeof(U));
     for (size_t i = 0; i < num; i++) {
         cv_to_ffi(source[i], &dest->array[i]);
     }
 }
-#endif  // UTILS_H_
+#endif // UTILS_H_

--- a/native/utils.h
+++ b/native/utils.h
@@ -14,9 +14,9 @@ template <typename T, typename U>
 void cv_to_ffi(const std::vector<T>& source, CVec<U>* dest) {
     size_t num = source.size();
     dest->size = num;
-    dest->array = (U*)malloc(num * sizeof(U));
+    dest->array = (U*) malloc(num * sizeof(U));
     for (size_t i = 0; i < num; i++) {
         cv_to_ffi(source[i], &dest->array[i]);
     }
 }
-#endif // UTILS_H_
+#endif  // UTILS_H_


### PR DESCRIPTION
- Check in .clang-format spec (based on LLVM)
- The source code in `native` has been formatted with `clang-format -i native/*`.
- Travis checks for clang-format diffs.
- Update `CONTRIBUTE.md` to include clang format check.

References: #40 

@Pzixel I am done with the clang format for now. So this is ready to review. Leave any style suggestions, or other implementation comments.