### PR TITLE
multithreaded hash

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -91,10 +91,10 @@ macro_rules! impl_hash {
 
         impl HashImplInterface for $x {}
 
-        // we know that this pointer is for calling virtual pure functions
-        // however, Rust doesn't allow us to share unsafe pointers between threads
-        // but it's save because the only place we mutate the pointer is `drop`,
-        // which makes the value inaccessible, so we're ok here too
+        // We know that this pointer is used for calling virtual pure functions,
+        // But Rust doesn't allow us to share unsafe pointers between threads.
+        // However, it's safe because the only place we mutate the pointer is `drop`,
+        // Which makes the value inaccessible, so we're ok here too
         unsafe impl Send for $x {}
         unsafe impl Sync for $x {}
     };

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -27,7 +27,7 @@ mod private {
     pub enum CHash {}
 
     pub trait HashImpl {
-        fn get_value(&self) -> *mut CHash;
+        fn get_value(&self) -> *const CHash;
     }
 }
 
@@ -64,7 +64,7 @@ macro_rules! impl_hash {
         #[doc=$description]
         #[derive(Debug)]
         pub struct $x {
-            value: *mut CHash,
+            value: *const CHash,
         }
 
         impl $x {
@@ -78,18 +78,25 @@ macro_rules! impl_hash {
         impl Drop for $x {
             fn drop(&mut self) {
                 unsafe {
-                    $drop(self.value);
+                    $drop(self.value as *mut _);
                 }
             }
         }
 
         impl HashImpl for $x {
-            fn get_value(&self) -> *mut CHash {
+            fn get_value(&self) -> *const CHash {
                 self.value
             }
         }
 
         impl HashImplInterface for $x {}
+
+        // we know that this pointer is for calling virtual pure functions
+        // however, Rust doesn't allow us to share unsafe pointers between threads
+        // but it's save because the only place we mutate the pointer is `drop`,
+        // which makes the value inaccessible, so we're ok here too
+        unsafe impl Send for $x {}
+        unsafe impl Sync for $x {}
     };
 }
 

--- a/tests/test_hash.rs
+++ b/tests/test_hash.rs
@@ -8,6 +8,15 @@ use cv::imgcodecs::ImageReadMode;
 use cv::*;
 use floatutils::*;
 use utils::*;
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn hash_multithreading() {
+    fn test_fn<T: Sync>(_: T) {}
+
+    let hash = Arc::new(Mutex::new(AverageHash::new()));
+    test_fn(hash);
+}
 
 #[test]
 fn average_hash_test() {

--- a/tests/test_hash.rs
+++ b/tests/test_hash.rs
@@ -8,14 +8,11 @@ use cv::imgcodecs::ImageReadMode;
 use cv::*;
 use floatutils::*;
 use utils::*;
-use std::sync::{Arc, Mutex};
 
 #[test]
 fn hash_multithreading() {
     fn test_fn<T: Sync>(_: T) {}
-
-    let hash = Arc::new(Mutex::new(AverageHash::new()));
-    test_fn(hash);
+    test_fn(AverageHash::new());
 }
 
 #[test]


### PR DESCRIPTION
My doogfooding has shown that I cannot use hashes from multithread environment (alhough it should be safe). Fix this.