### PR TITLE
Fmt fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - sudo -E ./.ci/install_cuda.sh
   - sudo -E ./.ci/travis_build_opencv.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib/x86_64-linux-gnu
-  - rustup component add rustfmt-preview
+  - rustup component add rustfmt-preview --toolchain nightly
   - cargo fmt --version
 
 script:
@@ -47,7 +47,7 @@ script:
   - cargo build --features tesseract
   - cargo test -v --features tesseract
   - cargo doc --features cuda --no-deps
-  - cargo fmt -- --write-mode=diff
+  - cargo fmt -- --check
   - diff -u <(cat native/*) <(clang-format native/*)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 
 language: rust
 rust:
-  - stable
+  - nightly
 
 addons:
   apt:
@@ -37,7 +37,7 @@ before_install:
   - sudo -E ./.ci/install_cuda.sh
   - sudo -E ./.ci/travis_build_opencv.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib/x86_64-linux-gnu
-  - rustup component add rustfmt-preview --toolchain nightly
+  - rustup component add rustfmt-preview
   - cargo fmt --version
 
 script:
@@ -47,7 +47,7 @@ script:
   - cargo build --features tesseract
   - cargo test -v --features tesseract
   - cargo doc --features cuda --no-deps
-  - cargo +nightly fmt -- --check
+  - cargo fmt -- --write-mode=diff
   - diff -u <(cat native/*) <(clang-format native/*)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - cargo build --features tesseract
   - cargo test -v --features tesseract
   - cargo doc --features cuda --no-deps
-  - cargo fmt -- --write-mode=diff
+  - cargo fmt -- --check
   - diff -u <(cat native/*) <(clang-format native/*)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - cargo build --features tesseract
   - cargo test -v --features tesseract
   - cargo doc --features cuda --no-deps
-  - cargo fmt -- --check
+  - cargo +nightly fmt -- --check
   - diff -u <(cat native/*) <(clang-format native/*)
 
 notifications:

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,8 @@ mod windows {
             ))
         })?;
         let lib = lib.file_name();
-        let lib = lib.into_string()
+        let lib = lib
+            .into_string()
             .map_err(|e| BuildError::new(format!("Cannot convert path '{:?}' to string", e)))?;
         // we expect filename to be something like 'open_world340.lib' or
         // 'open_world.340.dll.a', so we just consider everything after the

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -307,7 +307,8 @@ impl Mat {
     /// [Mat::at2](struct.Mat.html#method.at2).
     pub fn at3<T: FromBytes>(&self, i0: i32, i1: i32, i2: i32) -> T {
         let data = self.data();
-        let pos = i0 as usize * self.step1(0) * self.elem_size1() + i1 as usize * self.step1(1) * self.elem_size1()
+        let pos = i0 as usize * self.step1(0) * self.elem_size1()
+            + i1 as usize * self.step1(1) * self.elem_size1()
             + i2 as usize;
         let byte = &data[pos];
         let ptr: *const _ = byte;

--- a/src/videoio.rs
+++ b/src/videoio.rs
@@ -324,8 +324,10 @@ pub fn codec_name_from_4cc(value: &str) -> Result<u32, Error> {
         Err(CvError::UnicodeChars(value.into()).into())
     } else {
         let bytes = value.as_bytes();
-        let result = ((bytes[0] as u32) & 0xFFu32) + (((bytes[1] as u32) & 0xFFu32) << 8)
-            + (((bytes[2] as u32) & 0xFFu32) << 16) + (((bytes[3] as u32) & 0xFFu32) << 24);
+        let result = ((bytes[0] as u32) & 0xFFu32)
+            + (((bytes[1] as u32) & 0xFFu32) << 8)
+            + (((bytes[2] as u32) & 0xFFu32) << 16)
+            + (((bytes[3] as u32) & 0xFFu32) << 24);
         Ok(result)
     }
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 pub fn close_rect(a: Rect, b: Rect, epsilon: i32) -> bool {
-    ((a.x - b.x) < epsilon) && ((a.y - b.y) < epsilon) && (a.width - b.width) < epsilon
+    ((a.x - b.x) < epsilon)
+        && ((a.y - b.y) < epsilon)
+        && (a.width - b.width) < epsilon
         && (a.height - b.height) < epsilon
 }
 


### PR DESCRIPTION
This request fixes fmt issue of the repo.

The problem currently is that windows and linux `fmt` s differs a lot on stable channel. E.g. latest windows fmt is 0.6, when latest linux fmt is 0.4. It's quite confusing because you can have no diff on 0.4 but lots of changes on 0.6 and vice versa. Example of that is #87. 

This PR changes `fmt` to the nightly, which is same on both platforms with latest version `0.8`. 

fmt documentation says:

> For the latest and greatest rustfmt (nightly required):
> 
> ```bash
> rustup component add rustfmt-preview --toolchain nightly
> ```

They look pretty confident about its stability so I think it's much better alternative.